### PR TITLE
Document H2 auth seed script outside the backend

### DIFF
--- a/docs/database-design.md
+++ b/docs/database-design.md
@@ -59,5 +59,6 @@
 - `sys_role` 预置「管理员」「分析员」「查看者」三个角色。
 - `sys_permission` 预置菜单、接口权限分类，初期可与角色一一绑定。
 - `base_crop`、`base_region` 可导入典型作物与重点区域基础数据，为预测模型准备输入。
+- `docs/init-auth-data.sql` 提供 H2 环境下的权限与默认管理员账号初始化脚本，可在需要时手动执行。
 
 详细建表 SQL 见 `docs/database-schema.sql`。

--- a/docs/init-auth-data.sql
+++ b/docs/init-auth-data.sql
@@ -1,0 +1,34 @@
+-- H2 权限与默认用户初始化脚本
+-- 用于开发环境手动初始化，避免在应用启动时自动执行。
+
+DELETE FROM sys_role_permission;
+DELETE FROM sys_user_role;
+DELETE FROM sys_user;
+DELETE FROM sys_role;
+DELETE FROM sys_permission;
+
+INSERT INTO sys_permission (code, name)
+VALUES ('DATA_VIEW', '数据查看'),
+       ('DATA_MANAGE', '数据管理'),
+       ('USER_MANAGE', '用户管理');
+
+INSERT INTO sys_role (code, name)
+VALUES ('ADMIN', '系统管理员'),
+       ('ANALYST', '数据分析员');
+
+-- 为角色分配基础权限
+INSERT INTO sys_role_permission (role_id, permission_id)
+SELECT r.id, p.id
+FROM sys_role r
+         JOIN sys_permission p ON
+             (r.code = 'ADMIN' AND p.code IN ('DATA_VIEW', 'DATA_MANAGE', 'USER_MANAGE'))
+             OR (r.code = 'ANALYST' AND p.code = 'DATA_VIEW');
+
+INSERT INTO sys_user (username, password, full_name, email)
+VALUES ('admin', '{noop}admin123', '管理员', 'admin@example.com');
+
+INSERT INTO sys_user_role (user_id, role_id)
+SELECT u.id, r.id
+FROM sys_user u
+         JOIN sys_role r ON r.code = 'ADMIN'
+WHERE u.username = 'admin';


### PR DESCRIPTION
## Summary
- remove the automatic H2 schema/data initialization for auth tables from the Spring Boot resources
- add docs/init-auth-data.sql so the auth seed statements live alongside the rest of the database documentation
- mention the new manual seed script in the database design guide

## Testing
- `sh ./mvnw -DskipTests spring-boot:run -Dspring-boot.run.main-class=com.example.demo.DemoApplication`


------
https://chatgpt.com/codex/tasks/task_b_68ed06bd7bc0832cbc2af3d19a4d276a