### PR TITLE
Fix H2 security table initialization

### DIFF
--- a/demo/src/main/java/com/gxj/cropyield/common/response/ResultCode.java
+++ b/demo/src/main/java/com/gxj/cropyield/common/response/ResultCode.java
@@ -3,6 +3,7 @@ package com.gxj.cropyield.common.response;
 public enum ResultCode {
     SUCCESS(0, "success"),
     BAD_REQUEST(400, "bad_request"),
+    UNAUTHORIZED(401, "unauthorized"),
     NOT_FOUND(404, "not_found"),
     SERVER_ERROR(500, "server_error");
 

--- a/demo/src/main/resources/application-h2.yml
+++ b/demo/src/main/resources/application-h2.yml
@@ -11,6 +11,10 @@ spring:
     properties:
       hibernate:
         format_sql: true
+    defer-datasource-initialization: true
+  sql:
+    init:
+      mode: always
   jackson:
     date-format: yyyy-MM-dd HH:mm:ss
     time-zone: Asia/Shanghai

--- a/demo/src/main/resources/data.sql
+++ b/demo/src/main/resources/data.sql
@@ -1,3 +1,39 @@
+-- 初始化系统权限相关数据
+DELETE FROM sys_role_permission;
+DELETE FROM sys_user_role;
+DELETE FROM sys_user;
+DELETE FROM sys_role;
+DELETE FROM sys_permission;
+
+INSERT INTO sys_permission (code, name) VALUES
+    ('DASHBOARD_VIEW', '仪表盘查看'),
+    ('DATA_MANAGE', '数据资源管理'),
+    ('FORECAST_RUN', '预测任务执行');
+
+INSERT INTO sys_role (code, name) VALUES
+    ('ADMIN', '系统管理员'),
+    ('ANALYST', '农业分析员');
+
+INSERT INTO sys_user (username, password, full_name, email) VALUES
+    ('admin', '{noop}admin123', '系统管理员', 'admin@example.com'),
+    ('analyst', '{noop}analyst123', '农业分析员', 'analyst@example.com');
+
+INSERT INTO sys_role_permission (role_id, permission_id) VALUES
+    ((SELECT id FROM sys_role WHERE code = 'ADMIN'), (SELECT id FROM sys_permission WHERE code = 'DASHBOARD_VIEW')),
+    ((SELECT id FROM sys_role WHERE code = 'ADMIN'), (SELECT id FROM sys_permission WHERE code = 'DATA_MANAGE')),
+    ((SELECT id FROM sys_role WHERE code = 'ADMIN'), (SELECT id FROM sys_permission WHERE code = 'FORECAST_RUN')),
+    ((SELECT id FROM sys_role WHERE code = 'ANALYST'), (SELECT id FROM sys_permission WHERE code = 'DASHBOARD_VIEW')),
+    ((SELECT id FROM sys_role WHERE code = 'ANALYST'), (SELECT id FROM sys_permission WHERE code = 'FORECAST_RUN'));
+
+INSERT INTO sys_user_role (user_id, role_id) VALUES
+    ((SELECT id FROM sys_user WHERE username = 'admin'), (SELECT id FROM sys_role WHERE code = 'ADMIN')),
+    ((SELECT id FROM sys_user WHERE username = 'analyst'), (SELECT id FROM sys_role WHERE code = 'ANALYST'));
+
+-- 清理并导入基础业务数据
+DELETE FROM yield_records;
+DELETE FROM crops;
+DELETE FROM regions;
+
 INSERT INTO crops (name, category, description) VALUES
     ('水稻', '粮食作物', '云南主粮之一，集中分布在滇中和滇南稻区'),
     ('玉米', '粮食作物', '适宜山地丘陵地区，兼顾粮饲双用'),

--- a/demo/src/main/resources/schema.sql
+++ b/demo/src/main/resources/schema.sql
@@ -1,0 +1,48 @@
+-- Schema initialization for security tables required by data.sql
+DROP TABLE IF EXISTS sys_role_permission;
+DROP TABLE IF EXISTS sys_user_role;
+DROP TABLE IF EXISTS sys_user;
+DROP TABLE IF EXISTS sys_role;
+DROP TABLE IF EXISTS sys_permission;
+
+CREATE TABLE sys_permission (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    code VARCHAR(64) NOT NULL UNIQUE,
+    name VARCHAR(128) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+CREATE TABLE sys_role (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    code VARCHAR(64) NOT NULL UNIQUE,
+    name VARCHAR(128) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+CREATE TABLE sys_user (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(64) NOT NULL UNIQUE,
+    password VARCHAR(128) NOT NULL,
+    full_name VARCHAR(128),
+    email VARCHAR(128),
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+CREATE TABLE sys_user_role (
+    user_id BIGINT NOT NULL,
+    role_id BIGINT NOT NULL,
+    PRIMARY KEY (user_id, role_id),
+    CONSTRAINT fk_user_role_user FOREIGN KEY (user_id) REFERENCES sys_user (id) ON DELETE CASCADE,
+    CONSTRAINT fk_user_role_role FOREIGN KEY (role_id) REFERENCES sys_role (id) ON DELETE CASCADE
+);
+
+CREATE TABLE sys_role_permission (
+    role_id BIGINT NOT NULL,
+    permission_id BIGINT NOT NULL,
+    PRIMARY KEY (role_id, permission_id),
+    CONSTRAINT fk_role_perm_role FOREIGN KEY (role_id) REFERENCES sys_role (id) ON DELETE CASCADE,
+    CONSTRAINT fk_role_perm_permission FOREIGN KEY (permission_id) REFERENCES sys_permission (id) ON DELETE CASCADE
+);

--- a/docs/database-design.md
+++ b/docs/database-design.md
@@ -60,4 +60,4 @@
 - `sys_permission` 预置菜单、接口权限分类，初期可与角色一一绑定。
 - `base_crop`、`base_region` 可导入典型作物与重点区域基础数据，为预测模型准备输入。
 
-详细建表 SQL 见 `docs/database-schema.sql`。
+详细建表 SQL 见 `docs/database-schema.sql`，H2 环境初始化示例可参考 `docs/h2-auth-init.sql`。

--- a/docs/h2-auth-init.sql
+++ b/docs/h2-auth-init.sql
@@ -1,0 +1,30 @@
+-- H2 数据库环境下的系统权限初始化脚本
+DELETE FROM sys_role_permission;
+DELETE FROM sys_user_role;
+DELETE FROM sys_user;
+DELETE FROM sys_role;
+DELETE FROM sys_permission;
+
+INSERT INTO sys_permission (code, name) VALUES
+    ('DASHBOARD_VIEW', '仪表盘查看'),
+    ('DATA_MANAGE', '数据资源管理'),
+    ('FORECAST_RUN', '预测任务执行');
+
+INSERT INTO sys_role (code, name) VALUES
+    ('ADMIN', '系统管理员'),
+    ('ANALYST', '农业分析员');
+
+INSERT INTO sys_user (username, password, full_name, email) VALUES
+    ('admin', '{noop}admin123', '系统管理员', 'admin@example.com'),
+    ('analyst', '{noop}analyst123', '农业分析员', 'analyst@example.com');
+
+INSERT INTO sys_role_permission (role_id, permission_id) VALUES
+    ((SELECT id FROM sys_role WHERE code = 'ADMIN'), (SELECT id FROM sys_permission WHERE code = 'DASHBOARD_VIEW')),
+    ((SELECT id FROM sys_role WHERE code = 'ADMIN'), (SELECT id FROM sys_permission WHERE code = 'DATA_MANAGE')),
+    ((SELECT id FROM sys_role WHERE code = 'ADMIN'), (SELECT id FROM sys_permission WHERE code = 'FORECAST_RUN')),
+    ((SELECT id FROM sys_role WHERE code = 'ANALYST'), (SELECT id FROM sys_permission WHERE code = 'DASHBOARD_VIEW')),
+    ((SELECT id FROM sys_role WHERE code = 'ANALYST'), (SELECT id FROM sys_permission WHERE code = 'FORECAST_RUN'));
+
+INSERT INTO sys_user_role (user_id, role_id) VALUES
+    ((SELECT id FROM sys_user WHERE username = 'admin'), (SELECT id FROM sys_role WHERE code = 'ADMIN')),
+    ((SELECT id FROM sys_user WHERE username = 'analyst'), (SELECT id FROM sys_role WHERE code = 'ANALYST'));


### PR DESCRIPTION
## Summary
- add an explicit schema initializer so the sys_* security tables exist before loading seed data in H2
- extend the H2 data set with default permissions, roles, and users while documenting the script in docs

## Testing
- `mvn -q test` *(fails: existing CropYieldApplication context load error caused by duplicate SecurityConfig bean definitions)*

------
https://chatgpt.com/codex/tasks/task_b_68ed0bfb4890832c9f7442e1beeef02c