### PR TITLE
Add deletion workflow for imported datasets

### DIFF
--- a/demo/src/main/java/com/gxj/cropyield/datamanagement/DataImportController.java
+++ b/demo/src/main/java/com/gxj/cropyield/datamanagement/DataImportController.java
@@ -6,13 +6,17 @@ import com.gxj.cropyield.datamanagement.dto.DataImportJobPageResponse;
 import com.gxj.cropyield.datamanagement.dto.DataImportJobView;
 import com.gxj.cropyield.modules.dataset.entity.DatasetFile.DatasetType;
 import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
@@ -45,5 +49,11 @@ public class DataImportController {
     @GetMapping("/tasks/{taskId}")
     public ApiResponse<DataImportJobDetailView> getTask(@PathVariable String taskId) {
         return ApiResponse.success(dataImportService.getJobDetail(taskId));
+    }
+
+    @DeleteMapping("/tasks")
+    public ApiResponse<Void> deleteTasks(@RequestBody List<String> taskIds) {
+        dataImportService.deleteTasks(taskIds);
+        return ApiResponse.success();
     }
 }

--- a/demo/src/main/java/com/gxj/cropyield/datamanagement/DataImportService.java
+++ b/demo/src/main/java/com/gxj/cropyield/datamanagement/DataImportService.java
@@ -14,11 +14,10 @@ import com.gxj.cropyield.modules.base.entity.Crop;
 import com.gxj.cropyield.modules.base.entity.Region;
 import com.gxj.cropyield.modules.base.repository.CropRepository;
 import com.gxj.cropyield.modules.base.repository.RegionRepository;
-import com.gxj.cropyield.modules.dataset.dto.DatasetFileRequest;
 import com.gxj.cropyield.modules.dataset.dto.YieldRecordResponse;
+import com.gxj.cropyield.modules.dataset.entity.DatasetFile;
 import com.gxj.cropyield.modules.dataset.entity.DatasetFile.DatasetType;
 import com.gxj.cropyield.modules.dataset.repository.DatasetFileRepository;
-import com.gxj.cropyield.modules.dataset.service.DatasetFileService;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
@@ -32,7 +31,6 @@ import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.usermodel.WorkbookFactory;
 import org.springframework.dao.DataAccessException;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -67,7 +65,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -94,7 +91,6 @@ public class DataImportService {
 
     private final CropRepository cropRepository;
     private final RegionRepository regionRepository;
-    private final DatasetFileService datasetFileService;
     private final DatasetFileRepository datasetFileRepository;
     private final DataImportJobRepository jobRepository;
     private final JdbcTemplate jdbcTemplate;
@@ -102,14 +98,12 @@ public class DataImportService {
 
     public DataImportService(CropRepository cropRepository,
                              RegionRepository regionRepository,
-                             DatasetFileService datasetFileService,
                              DatasetFileRepository datasetFileRepository,
                              DataImportJobRepository jobRepository,
                              JdbcTemplate jdbcTemplate,
                              ObjectMapper objectMapper) {
         this.cropRepository = cropRepository;
         this.regionRepository = regionRepository;
-        this.datasetFileService = datasetFileService;
         this.datasetFileRepository = datasetFileRepository;
         this.jobRepository = jobRepository;
         this.jdbcTemplate = jdbcTemplate;
@@ -224,12 +218,14 @@ public class DataImportService {
                 }
             }
 
+            DatasetFile datasetFile = null;
             int inserted = 0;
             int updated = 0;
             if (!validRecords.isEmpty()) {
+                datasetFile = ensureDatasetFile(job);
                 job.setMessage("正在批量写入数据库");
                 jobRepository.save(job);
-                UpsertResult result = upsertRecords(validRecords);
+                UpsertResult result = upsertRecords(validRecords, datasetFile);
                 inserted = result.inserted();
                 updated = result.updated();
             }
@@ -253,8 +249,8 @@ public class DataImportService {
             job.setMessage(buildCompletionMessage(job));
             jobRepository.save(job);
 
-            if (inserted + updated > 0) {
-                upsertDatasetFile(job);
+            if (datasetFile != null) {
+                updateDatasetFileMetadata(datasetFile, job);
             }
         } catch (Exception exception) {
             job.setStatus(DataImportJobStatus.FAILED);
@@ -264,27 +260,34 @@ public class DataImportService {
         }
     }
 
-    private void upsertDatasetFile(DataImportJob job) {
-        DatasetFileRequest request = new DatasetFileRequest(
-                job.getDatasetName(),
-                job.getDatasetType(),
-                job.getStoragePath(),
-                buildDatasetDescription(job)
-        );
-        try {
-            datasetFileService.create(request);
-        } catch (DataIntegrityViolationException exception) {
-            datasetFileRepository.findByName(job.getDatasetName())
-                    .ifPresent(existing -> {
-                        existing.setType(job.getDatasetType());
-                        existing.setStoragePath(job.getStoragePath());
-                        existing.setDescription(request.description());
-                        datasetFileRepository.save(existing);
-                    });
-        }
+    private DatasetFile ensureDatasetFile(DataImportJob job) {
+        return datasetFileRepository.findByName(job.getDatasetName())
+                .map(existing -> {
+                    existing.setType(job.getDatasetType());
+                    existing.setStoragePath(job.getStoragePath());
+                    if (job.getDatasetDescription() != null && !job.getDatasetDescription().isBlank()) {
+                        existing.setDescription(job.getDatasetDescription());
+                    }
+                    return datasetFileRepository.save(existing);
+                })
+                .orElseGet(() -> {
+                    DatasetFile created = new DatasetFile();
+                    created.setName(job.getDatasetName());
+                    created.setType(job.getDatasetType());
+                    created.setStoragePath(job.getStoragePath());
+                    created.setDescription(job.getDatasetDescription());
+                    return datasetFileRepository.save(created);
+                });
     }
 
-    private UpsertResult upsertRecords(List<ValidRecord> records) {
+    private void updateDatasetFileMetadata(DatasetFile datasetFile, DataImportJob job) {
+        datasetFile.setType(job.getDatasetType());
+        datasetFile.setStoragePath(job.getStoragePath());
+        datasetFile.setDescription(buildDatasetDescription(job));
+        datasetFileRepository.save(datasetFile);
+    }
+
+    private UpsertResult upsertRecords(List<ValidRecord> records, DatasetFile datasetFile) {
         int batchSize = 500;
         int inserted = 0;
         int updated = 0;
@@ -292,9 +295,10 @@ public class DataImportService {
             List<ValidRecord> batch = records.subList(i, Math.min(i + batchSize, records.size()));
             Set<RowKey> existing = fetchExistingKeys(batch);
             String sql = """
-                    INSERT INTO dataset_yield_record (crop_id, region_id, year, sown_area, production, yield_per_hectare, average_price, data_source, collected_at, created_at, updated_at)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
+                    INSERT INTO dataset_yield_record (dataset_file_id, crop_id, region_id, year, sown_area, production, yield_per_hectare, average_price, data_source, collected_at, created_at, updated_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
                     ON DUPLICATE KEY UPDATE
+                        dataset_file_id = VALUES(dataset_file_id),
                         sown_area = VALUES(sown_area),
                         production = VALUES(production),
                         yield_per_hectare = VALUES(yield_per_hectare),
@@ -305,18 +309,19 @@ public class DataImportService {
                     """;
             try {
                 jdbcTemplate.batchUpdate(sql, batch, batch.size(), (preparedStatement, record) -> {
-                    preparedStatement.setLong(1, record.crop().getId());
-                    preparedStatement.setLong(2, record.region().getId());
-                    preparedStatement.setInt(3, record.year());
-                    setNullableDouble(preparedStatement, 4, record.sownArea());
-                    setNullableDouble(preparedStatement, 5, record.production());
-                    setNullableDouble(preparedStatement, 6, record.yieldPerHectare());
-                    setNullableDouble(preparedStatement, 7, record.averagePrice());
-                    preparedStatement.setString(8, record.dataSource());
+                    preparedStatement.setLong(1, datasetFile.getId());
+                    preparedStatement.setLong(2, record.crop().getId());
+                    preparedStatement.setLong(3, record.region().getId());
+                    preparedStatement.setInt(4, record.year());
+                    setNullableDouble(preparedStatement, 5, record.sownArea());
+                    setNullableDouble(preparedStatement, 6, record.production());
+                    setNullableDouble(preparedStatement, 7, record.yieldPerHectare());
+                    setNullableDouble(preparedStatement, 8, record.averagePrice());
+                    preparedStatement.setString(9, record.dataSource());
                     if (record.collectedAt() != null) {
-                        preparedStatement.setObject(9, java.sql.Date.valueOf(record.collectedAt()));
+                        preparedStatement.setObject(10, java.sql.Date.valueOf(record.collectedAt()));
                     } else {
-                        preparedStatement.setObject(9, null);
+                        preparedStatement.setObject(10, null);
                     }
                 });
             } catch (DataAccessException exception) {

--- a/demo/src/main/java/com/gxj/cropyield/datamanagement/dto/DataImportJobView.java
+++ b/demo/src/main/java/com/gxj/cropyield/datamanagement/dto/DataImportJobView.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 
 public record DataImportJobView(
         String taskId,
+        Long datasetFileId,
         String datasetName,
         DatasetType datasetType,
         String originalFilename,

--- a/demo/src/main/java/com/gxj/cropyield/datamanagement/model/DataImportJob.java
+++ b/demo/src/main/java/com/gxj/cropyield/datamanagement/model/DataImportJob.java
@@ -37,6 +37,9 @@ public class DataImportJob extends BaseEntity {
     @Column(name = "dataset_type", nullable = false, length = 32)
     private DatasetType datasetType;
 
+    @Column(name = "dataset_file_id")
+    private Long datasetFileId;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 32)
     private DataImportJobStatus status = DataImportJobStatus.QUEUED;
@@ -118,6 +121,14 @@ public class DataImportJob extends BaseEntity {
 
     public void setDatasetType(DatasetType datasetType) {
         this.datasetType = datasetType;
+    }
+
+    public Long getDatasetFileId() {
+        return datasetFileId;
+    }
+
+    public void setDatasetFileId(Long datasetFileId) {
+        this.datasetFileId = datasetFileId;
     }
 
     public DataImportJobStatus getStatus() {

--- a/demo/src/main/java/com/gxj/cropyield/datamanagement/repository/DataImportJobRepository.java
+++ b/demo/src/main/java/com/gxj/cropyield/datamanagement/repository/DataImportJobRepository.java
@@ -4,9 +4,17 @@ import com.gxj.cropyield.datamanagement.model.DataImportJob;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface DataImportJobRepository extends JpaRepository<DataImportJob, Long>, JpaSpecificationExecutor<DataImportJob> {
 
     Optional<DataImportJob> findByTaskId(String taskId);
+
+    List<DataImportJob> findByTaskIdIn(Collection<String> taskIds);
+
+    List<DataImportJob> findByDatasetFileId(Long datasetFileId);
+
+    List<DataImportJob> findByDatasetName(String datasetName);
 }

--- a/demo/src/main/java/com/gxj/cropyield/modules/dataset/config/DatasetSchemaMigrator.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/dataset/config/DatasetSchemaMigrator.java
@@ -23,6 +23,7 @@ public class DatasetSchemaMigrator implements ApplicationRunner {
     public void run(ApplicationArguments args) {
         ensureDatasetFileColumn("dataset_yield_record", "idx_yield_dataset_file", "fk_yield_dataset_file");
         ensureDatasetFileColumn("dataset_price_record", "idx_price_dataset_file", "fk_price_dataset_file");
+        ensureImportJobColumn();
     }
 
     private void ensureDatasetFileColumn(String tableName, String indexName, String constraintName) {
@@ -40,6 +41,25 @@ public class DatasetSchemaMigrator implements ApplicationRunner {
             String ddl = "ALTER TABLE " + tableName +
                     " ADD CONSTRAINT " + constraintName +
                     " FOREIGN KEY (dataset_file_id) REFERENCES dataset_file (id) ON DELETE CASCADE";
+            executeDdl(tableName, "add dataset_file foreign key", ddl);
+        }
+    }
+
+    private void ensureImportJobColumn() {
+        String tableName = "data_import_job";
+        if (!columnExists(tableName, "dataset_file_id")) {
+            String ddl = "ALTER TABLE " + tableName +
+                    " ADD COLUMN dataset_file_id BIGINT UNSIGNED NULL AFTER dataset_type";
+            executeDdl(tableName, "add dataset_file_id column", ddl);
+        }
+        if (!indexExists(tableName, "idx_import_dataset_file")) {
+            String ddl = "ALTER TABLE " + tableName +
+                    " ADD INDEX idx_import_dataset_file (dataset_file_id)";
+            executeDdl(tableName, "add dataset_file index", ddl);
+        }
+        if (!foreignKeyExists(tableName, "fk_import_dataset_file")) {
+            String ddl = "ALTER TABLE " + tableName +
+                    " ADD CONSTRAINT fk_import_dataset_file FOREIGN KEY (dataset_file_id) REFERENCES dataset_file (id) ON DELETE SET NULL";
             executeDdl(tableName, "add dataset_file foreign key", ddl);
         }
     }

--- a/demo/src/main/java/com/gxj/cropyield/modules/dataset/config/DatasetSchemaMigrator.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/dataset/config/DatasetSchemaMigrator.java
@@ -1,0 +1,85 @@
+package com.gxj.cropyield.modules.dataset.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DatasetSchemaMigrator implements ApplicationRunner {
+
+    private static final Logger log = LoggerFactory.getLogger(DatasetSchemaMigrator.class);
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public DatasetSchemaMigrator(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        ensureDatasetFileColumn("dataset_yield_record", "idx_yield_dataset_file", "fk_yield_dataset_file");
+        ensureDatasetFileColumn("dataset_price_record", "idx_price_dataset_file", "fk_price_dataset_file");
+    }
+
+    private void ensureDatasetFileColumn(String tableName, String indexName, String constraintName) {
+        if (!columnExists(tableName, "dataset_file_id")) {
+            String ddl = "ALTER TABLE " + tableName +
+                    " ADD COLUMN dataset_file_id BIGINT UNSIGNED NULL AFTER id";
+            executeDdl(tableName, "add dataset_file_id column", ddl);
+        }
+        if (!indexExists(tableName, indexName)) {
+            String ddl = "ALTER TABLE " + tableName +
+                    " ADD INDEX " + indexName + " (dataset_file_id)";
+            executeDdl(tableName, "add dataset_file_id index", ddl);
+        }
+        if (!foreignKeyExists(tableName, constraintName)) {
+            String ddl = "ALTER TABLE " + tableName +
+                    " ADD CONSTRAINT " + constraintName +
+                    " FOREIGN KEY (dataset_file_id) REFERENCES dataset_file (id) ON DELETE CASCADE";
+            executeDdl(tableName, "add dataset_file foreign key", ddl);
+        }
+    }
+
+    private boolean columnExists(String tableName, String columnName) {
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?",
+                Integer.class,
+                tableName,
+                columnName
+        );
+        return count != null && count > 0;
+    }
+
+    private boolean indexExists(String tableName, String indexName) {
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM information_schema.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND INDEX_NAME = ?",
+                Integer.class,
+                tableName,
+                indexName
+        );
+        return count != null && count > 0;
+    }
+
+    private boolean foreignKeyExists(String tableName, String constraintName) {
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND CONSTRAINT_NAME = ?",
+                Integer.class,
+                tableName,
+                constraintName
+        );
+        return count != null && count > 0;
+    }
+
+    private void executeDdl(String tableName, String description, String ddl) {
+        try {
+            jdbcTemplate.execute(ddl);
+            log.info("{}: {} executed", tableName, description);
+        } catch (DataAccessException ex) {
+            log.warn("Failed to {} for table {}: {}", description, tableName, ex.getMessage());
+        }
+    }
+}

--- a/demo/src/main/java/com/gxj/cropyield/modules/dataset/controller/DatasetFileController.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/dataset/controller/DatasetFileController.java
@@ -5,6 +5,7 @@ import com.gxj.cropyield.modules.dataset.dto.DatasetFileRequest;
 import com.gxj.cropyield.modules.dataset.entity.DatasetFile;
 import com.gxj.cropyield.modules.dataset.service.DatasetFileService;
 import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -31,5 +32,11 @@ public class DatasetFileController {
     @PostMapping
     public ApiResponse<DatasetFile> createFile(@Valid @RequestBody DatasetFileRequest request) {
         return ApiResponse.success(datasetFileService.create(request));
+    }
+
+    @DeleteMapping
+    public ApiResponse<Void> deleteFiles(@RequestBody List<Long> ids) {
+        datasetFileService.deleteByIds(ids);
+        return ApiResponse.success();
     }
 }

--- a/demo/src/main/java/com/gxj/cropyield/modules/dataset/entity/PriceRecord.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/dataset/entity/PriceRecord.java
@@ -3,6 +3,7 @@ package com.gxj.cropyield.modules.dataset.entity;
 import com.gxj.cropyield.common.model.BaseEntity;
 import com.gxj.cropyield.modules.base.entity.Crop;
 import com.gxj.cropyield.modules.base.entity.Region;
+import com.gxj.cropyield.modules.dataset.entity.DatasetFile;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -24,6 +25,10 @@ public class PriceRecord extends BaseEntity {
     @JoinColumn(name = "region_id", nullable = false)
     private Region region;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "dataset_file_id")
+    private DatasetFile datasetFile;
+
     @Column(nullable = false)
     private LocalDate recordDate;
 
@@ -44,6 +49,14 @@ public class PriceRecord extends BaseEntity {
 
     public void setRegion(Region region) {
         this.region = region;
+    }
+
+    public DatasetFile getDatasetFile() {
+        return datasetFile;
+    }
+
+    public void setDatasetFile(DatasetFile datasetFile) {
+        this.datasetFile = datasetFile;
     }
 
     public LocalDate getRecordDate() {

--- a/demo/src/main/java/com/gxj/cropyield/modules/dataset/entity/YieldRecord.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/dataset/entity/YieldRecord.java
@@ -3,6 +3,7 @@ package com.gxj.cropyield.modules.dataset.entity;
 import com.gxj.cropyield.common.model.BaseEntity;
 import com.gxj.cropyield.modules.base.entity.Crop;
 import com.gxj.cropyield.modules.base.entity.Region;
+import com.gxj.cropyield.modules.dataset.entity.DatasetFile;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -21,6 +22,10 @@ public class YieldRecord extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "region_id", nullable = false)
     private Region region;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "dataset_file_id")
+    private DatasetFile datasetFile;
 
     @Column(nullable = false)
     private Integer year;
@@ -57,6 +62,14 @@ public class YieldRecord extends BaseEntity {
 
     public void setRegion(Region region) {
         this.region = region;
+    }
+
+    public DatasetFile getDatasetFile() {
+        return datasetFile;
+    }
+
+    public void setDatasetFile(DatasetFile datasetFile) {
+        this.datasetFile = datasetFile;
     }
 
     public Integer getYear() {

--- a/demo/src/main/java/com/gxj/cropyield/modules/dataset/repository/PriceRecordRepository.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/dataset/repository/PriceRecordRepository.java
@@ -2,8 +2,22 @@ package com.gxj.cropyield.modules.dataset.repository;
 
 import com.gxj.cropyield.modules.dataset.entity.PriceRecord;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface PriceRecordRepository extends JpaRepository<PriceRecord, Long> {
 
     Long deleteByDatasetFileId(Long datasetFileId);
+
+    boolean existsByCropId(Long cropId);
+
+    boolean existsByRegionId(Long regionId);
+
+    @Query("select distinct record.crop.id from PriceRecord record where record.datasetFile.id = :datasetFileId")
+    List<Long> findDistinctCropIdsByDatasetFileId(@Param("datasetFileId") Long datasetFileId);
+
+    @Query("select distinct record.region.id from PriceRecord record where record.datasetFile.id = :datasetFileId")
+    List<Long> findDistinctRegionIdsByDatasetFileId(@Param("datasetFileId") Long datasetFileId);
 }

--- a/demo/src/main/java/com/gxj/cropyield/modules/dataset/repository/PriceRecordRepository.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/dataset/repository/PriceRecordRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PriceRecordRepository extends JpaRepository<PriceRecord, Long> {
 
-    long deleteByDatasetFileId(Long datasetFileId);
+    Long deleteByDatasetFileId(Long datasetFileId);
 }

--- a/demo/src/main/java/com/gxj/cropyield/modules/dataset/repository/PriceRecordRepository.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/dataset/repository/PriceRecordRepository.java
@@ -4,4 +4,6 @@ import com.gxj.cropyield.modules.dataset.entity.PriceRecord;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PriceRecordRepository extends JpaRepository<PriceRecord, Long> {
+
+    long deleteByDatasetFileId(Long datasetFileId);
 }

--- a/demo/src/main/java/com/gxj/cropyield/modules/dataset/repository/YieldRecordRepository.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/dataset/repository/YieldRecordRepository.java
@@ -20,6 +20,16 @@ public interface YieldRecordRepository extends JpaRepository<YieldRecord, Long> 
 
     Long deleteByDatasetFileId(Long datasetFileId);
 
+    boolean existsByCropId(Long cropId);
+
+    boolean existsByRegionId(Long regionId);
+
+    @Query("select distinct record.crop.id from YieldRecord record where record.datasetFile.id = :datasetFileId")
+    List<Long> findDistinctCropIdsByDatasetFileId(@Param("datasetFileId") Long datasetFileId);
+
+    @Query("select distinct record.region.id from YieldRecord record where record.datasetFile.id = :datasetFileId")
+    List<Long> findDistinctRegionIdsByDatasetFileId(@Param("datasetFileId") Long datasetFileId);
+
     @Query("""
             SELECT record FROM YieldRecord record
             WHERE (:cropId IS NULL OR record.crop.id = :cropId)

--- a/demo/src/main/java/com/gxj/cropyield/modules/dataset/repository/YieldRecordRepository.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/dataset/repository/YieldRecordRepository.java
@@ -18,6 +18,8 @@ public interface YieldRecordRepository extends JpaRepository<YieldRecord, Long> 
 
     List<YieldRecord> findTop5ByOrderByYearDesc();
 
+    long deleteByDatasetFileId(Long datasetFileId);
+
     @Query("""
             SELECT record FROM YieldRecord record
             WHERE (:cropId IS NULL OR record.crop.id = :cropId)

--- a/demo/src/main/java/com/gxj/cropyield/modules/dataset/repository/YieldRecordRepository.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/dataset/repository/YieldRecordRepository.java
@@ -18,7 +18,7 @@ public interface YieldRecordRepository extends JpaRepository<YieldRecord, Long> 
 
     List<YieldRecord> findTop5ByOrderByYearDesc();
 
-    long deleteByDatasetFileId(Long datasetFileId);
+    Long deleteByDatasetFileId(Long datasetFileId);
 
     @Query("""
             SELECT record FROM YieldRecord record

--- a/demo/src/main/java/com/gxj/cropyield/modules/dataset/service/DatasetFileService.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/dataset/service/DatasetFileService.java
@@ -10,4 +10,6 @@ public interface DatasetFileService {
     List<DatasetFile> listAll();
 
     DatasetFile create(DatasetFileRequest request);
+
+    void deleteByIds(List<Long> ids);
 }

--- a/demo/src/main/java/com/gxj/cropyield/modules/dataset/service/impl/DatasetFileServiceImpl.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/dataset/service/impl/DatasetFileServiceImpl.java
@@ -72,11 +72,12 @@ public class DatasetFileServiceImpl implements DatasetFileService {
         if (type == null || file.getId() == null) {
             return 0L;
         }
-        return switch (type) {
+        Long removed = switch (type) {
             case YIELD -> yieldRecordRepository.deleteByDatasetFileId(file.getId());
             case PRICE -> priceRecordRepository.deleteByDatasetFileId(file.getId());
             default -> 0L;
         };
+        return removed == null ? 0L : removed;
     }
 
     private void recordDeletionJob(DatasetFile file, long removedRecords) {

--- a/demo/src/main/java/com/gxj/cropyield/modules/dataset/service/impl/DatasetFileServiceImpl.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/dataset/service/impl/DatasetFileServiceImpl.java
@@ -31,4 +31,12 @@ public class DatasetFileServiceImpl implements DatasetFileService {
         datasetFile.setDescription(request.description());
         return datasetFileRepository.save(datasetFile);
     }
+
+    @Override
+    public void deleteByIds(List<Long> ids) {
+        if (ids == null || ids.isEmpty()) {
+            return;
+        }
+        datasetFileRepository.deleteAllById(ids);
+    }
 }

--- a/demo/src/main/java/com/gxj/cropyield/modules/dataset/service/impl/DatasetFileServiceImpl.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/dataset/service/impl/DatasetFileServiceImpl.java
@@ -1,20 +1,38 @@
 package com.gxj.cropyield.modules.dataset.service.impl;
 
+import com.gxj.cropyield.datamanagement.model.DataImportJob;
+import com.gxj.cropyield.datamanagement.model.DataImportJobStatus;
+import com.gxj.cropyield.datamanagement.repository.DataImportJobRepository;
 import com.gxj.cropyield.modules.dataset.dto.DatasetFileRequest;
 import com.gxj.cropyield.modules.dataset.entity.DatasetFile;
+import com.gxj.cropyield.modules.dataset.entity.DatasetFile.DatasetType;
 import com.gxj.cropyield.modules.dataset.repository.DatasetFileRepository;
+import com.gxj.cropyield.modules.dataset.repository.PriceRecordRepository;
+import com.gxj.cropyield.modules.dataset.repository.YieldRecordRepository;
 import com.gxj.cropyield.modules.dataset.service.DatasetFileService;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 
 @Service
 public class DatasetFileServiceImpl implements DatasetFileService {
 
     private final DatasetFileRepository datasetFileRepository;
+    private final YieldRecordRepository yieldRecordRepository;
+    private final PriceRecordRepository priceRecordRepository;
+    private final DataImportJobRepository jobRepository;
 
-    public DatasetFileServiceImpl(DatasetFileRepository datasetFileRepository) {
+    public DatasetFileServiceImpl(DatasetFileRepository datasetFileRepository,
+                                  YieldRecordRepository yieldRecordRepository,
+                                  PriceRecordRepository priceRecordRepository,
+                                  DataImportJobRepository jobRepository) {
         this.datasetFileRepository = datasetFileRepository;
+        this.yieldRecordRepository = yieldRecordRepository;
+        this.priceRecordRepository = priceRecordRepository;
+        this.jobRepository = jobRepository;
     }
 
     @Override
@@ -33,10 +51,55 @@ public class DatasetFileServiceImpl implements DatasetFileService {
     }
 
     @Override
+    @Transactional
     public void deleteByIds(List<Long> ids) {
         if (ids == null || ids.isEmpty()) {
             return;
         }
-        datasetFileRepository.deleteAllById(ids);
+        List<DatasetFile> files = datasetFileRepository.findAllById(ids);
+        if (files.isEmpty()) {
+            return;
+        }
+        for (DatasetFile file : files) {
+            long removed = cleanupDatasetRecords(file);
+            recordDeletionJob(file, removed);
+        }
+        datasetFileRepository.deleteAll(files);
+    }
+
+    private long cleanupDatasetRecords(DatasetFile file) {
+        DatasetType type = file.getType();
+        if (type == null || file.getId() == null) {
+            return 0L;
+        }
+        return switch (type) {
+            case YIELD -> yieldRecordRepository.deleteByDatasetFileId(file.getId());
+            case PRICE -> priceRecordRepository.deleteByDatasetFileId(file.getId());
+            default -> 0L;
+        };
+    }
+
+    private void recordDeletionJob(DatasetFile file, long removedRecords) {
+        DataImportJob job = new DataImportJob();
+        job.setTaskId("DELETE-" + UUID.randomUUID());
+        job.setDatasetName(file.getName());
+        job.setDatasetDescription(file.getDescription());
+        job.setDatasetType(file.getType());
+        job.setStatus(DataImportJobStatus.SUCCEEDED);
+        job.setOriginalFilename(file.getName());
+        job.setStoragePath(file.getStoragePath());
+        int processed = removedRecords > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) removedRecords;
+        job.setTotalRows(processed);
+        job.setProcessedRows(processed);
+        job.setInsertedRows(0);
+        job.setUpdatedRows(0);
+        job.setSkippedRows(0);
+        job.setFailedRows(0);
+        job.setWarningCount(0);
+        job.setMessage("数据集已删除，清理 " + removedRecords + " 条入库记录");
+        LocalDateTime now = LocalDateTime.now();
+        job.setStartedAt(now);
+        job.setFinishedAt(now);
+        jobRepository.save(job);
     }
 }

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/repository/ForecastModelRepository.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/repository/ForecastModelRepository.java
@@ -3,5 +3,8 @@ package com.gxj.cropyield.modules.forecast.repository;
 import com.gxj.cropyield.modules.forecast.entity.ForecastModel;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ForecastModelRepository extends JpaRepository<ForecastModel, Long> {
+    Optional<ForecastModel> findByName(String name);
 }

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/repository/ForecastRunRepository.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/repository/ForecastRunRepository.java
@@ -4,4 +4,8 @@ import com.gxj.cropyield.modules.forecast.entity.ForecastRun;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ForecastRunRepository extends JpaRepository<ForecastRun, Long> {
+
+    boolean existsByCropId(Long cropId);
+
+    boolean existsByRegionId(Long regionId);
 }

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/repository/ForecastTaskRepository.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/repository/ForecastTaskRepository.java
@@ -4,4 +4,8 @@ import com.gxj.cropyield.modules.forecast.entity.ForecastTask;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ForecastTaskRepository extends JpaRepository<ForecastTask, Long> {
+
+    boolean existsByCropId(Long cropId);
+
+    boolean existsByRegionId(Long regionId);
 }

--- a/demo/src/main/resources/data.sql
+++ b/demo/src/main/resources/data.sql
@@ -33,13 +33,13 @@ ON DUPLICATE KEY UPDATE
     description = VALUES(description);
 
 -- 初始化作物年均单产示例数据
-INSERT INTO dataset_yield_record (id, crop_id, region_id, year, sown_area, production, yield_per_hectare, average_price, data_source, collected_at)
+INSERT INTO dataset_yield_record (id, dataset_file_id, crop_id, region_id, year, sown_area, production, yield_per_hectare, average_price, data_source, collected_at)
 VALUES
-    (1, 1, 2, 2021, 356.2, 198.4, 5.6, 2.35, '云南省农业农村厅年报', '2021-12-31'),
-    (2, 1, 2, 2022, 360.5, 209.0, 5.8, 2.38, '云南省农业农村厅年报', '2022-12-31'),
-    (3, 1, 2, 2023, 365.0, 219.0, 6.0, 2.42, '云南省农业农村厅年报', '2023-12-31'),
-    (4, 2, 2, 2023, 420.8, 353.5, 8.4, 2.15, '云南省农业农村厅年报', '2023-12-31'),
-    (5, 1, 3, 2023, 52.4, 33.0, 6.3, 2.45, '昆明市统计局', '2023-12-31')
+    (1, 1, 1, 2, 2021, 356.2, 198.4, 5.6, 2.35, '云南省农业农村厅年报', '2021-12-31'),
+    (2, 1, 1, 2, 2022, 360.5, 209.0, 5.8, 2.38, '云南省农业农村厅年报', '2022-12-31'),
+    (3, 1, 1, 2, 2023, 365.0, 219.0, 6.0, 2.42, '云南省农业农村厅年报', '2023-12-31'),
+    (4, 1, 2, 2, 2023, 420.8, 353.5, 8.4, 2.15, '云南省农业农村厅年报', '2023-12-31'),
+    (5, 1, 1, 3, 2023, 52.4, 33.0, 6.3, 2.45, '昆明市统计局', '2023-12-31')
 ON DUPLICATE KEY UPDATE
     sown_area = VALUES(sown_area),
     production = VALUES(production),
@@ -49,13 +49,13 @@ ON DUPLICATE KEY UPDATE
     collected_at = VALUES(collected_at);
 
 -- 初始化作物价格示例数据
-INSERT INTO dataset_price_record (id, crop_id, region_id, record_date, price)
+INSERT INTO dataset_price_record (id, dataset_file_id, crop_id, region_id, record_date, price)
 VALUES
-    (1, 1, 2, '2023-05-01', 2360.00),
-    (2, 1, 2, '2023-06-01', 2385.00),
-    (3, 1, 2, '2023-07-01', 2402.00),
-    (4, 2, 2, '2023-07-01', 2150.00),
-    (5, 1, 3, '2023-07-01', 2450.00)
+    (1, 2, 1, 2, '2023-05-01', 2360.00),
+    (2, 2, 1, 2, '2023-06-01', 2385.00),
+    (3, 2, 1, 2, '2023-07-01', 2402.00),
+    (4, 2, 2, 2, '2023-07-01', 2150.00),
+    (5, 2, 1, 3, '2023-07-01', 2450.00)
 ON DUPLICATE KEY UPDATE
     price = VALUES(price);
 

--- a/demo/src/main/resources/schema.sql
+++ b/demo/src/main/resources/schema.sql
@@ -44,6 +44,7 @@ CREATE TABLE IF NOT EXISTS data_import_job (
     dataset_name VARCHAR(128),
     dataset_description VARCHAR(256),
     dataset_type VARCHAR(32) NOT NULL,
+    dataset_file_id BIGINT UNSIGNED,
     status VARCHAR(32) NOT NULL,
     original_filename VARCHAR(256),
     storage_path VARCHAR(512),
@@ -62,7 +63,9 @@ CREATE TABLE IF NOT EXISTS data_import_job (
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     UNIQUE KEY uq_import_task (task_id),
-    KEY idx_import_status (status)
+    KEY idx_import_status (status),
+    KEY idx_import_dataset_file (dataset_file_id),
+    CONSTRAINT fk_import_dataset_file FOREIGN KEY (dataset_file_id) REFERENCES dataset_file (id) ON DELETE SET NULL
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COMMENT = '数据导入任务记录';
 
 CREATE TABLE IF NOT EXISTS data_import_job_error (

--- a/demo/src/main/resources/schema.sql
+++ b/demo/src/main/resources/schema.sql
@@ -80,6 +80,7 @@ CREATE TABLE IF NOT EXISTS data_import_job_error (
 
 CREATE TABLE IF NOT EXISTS dataset_yield_record (
     id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    dataset_file_id BIGINT UNSIGNED,
     crop_id BIGINT UNSIGNED NOT NULL,
     region_id BIGINT UNSIGNED NOT NULL,
     year INT NOT NULL,
@@ -92,14 +93,17 @@ CREATE TABLE IF NOT EXISTS dataset_yield_record (
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     UNIQUE KEY uq_yield_crop_region_year (crop_id, region_id, year),
+    KEY idx_yield_dataset_file (dataset_file_id),
     KEY idx_yield_crop (crop_id),
     KEY idx_yield_region (region_id),
+    CONSTRAINT fk_yield_dataset_file FOREIGN KEY (dataset_file_id) REFERENCES dataset_file (id) ON DELETE CASCADE,
     CONSTRAINT fk_yield_crop FOREIGN KEY (crop_id) REFERENCES base_crop (id) ON DELETE CASCADE,
     CONSTRAINT fk_yield_region FOREIGN KEY (region_id) REFERENCES base_region (id) ON DELETE CASCADE
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COMMENT = '作物年均单产记录';
 
 CREATE TABLE IF NOT EXISTS dataset_price_record (
     id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    dataset_file_id BIGINT UNSIGNED,
     crop_id BIGINT UNSIGNED NOT NULL,
     region_id BIGINT UNSIGNED NOT NULL,
     record_date DATE NOT NULL,
@@ -107,8 +111,10 @@ CREATE TABLE IF NOT EXISTS dataset_price_record (
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     UNIQUE KEY uq_price_crop_region_date (crop_id, region_id, record_date),
+    KEY idx_price_dataset_file (dataset_file_id),
     KEY idx_price_crop (crop_id),
     KEY idx_price_region (region_id),
+    CONSTRAINT fk_price_dataset_file FOREIGN KEY (dataset_file_id) REFERENCES dataset_file (id) ON DELETE CASCADE,
     CONSTRAINT fk_price_crop FOREIGN KEY (crop_id) REFERENCES base_crop (id) ON DELETE CASCADE,
     CONSTRAINT fk_price_region FOREIGN KEY (region_id) REFERENCES base_region (id) ON DELETE CASCADE
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COMMENT = '作物价格时间序列';

--- a/forecast/src/views/DataCenterView.vue
+++ b/forecast/src/views/DataCenterView.vue
@@ -367,7 +367,7 @@ const deleteSelectedDatasets = async () => {
     await apiClient.delete('/api/datasets/files', { data: ids })
     ElMessage.success('已删除选中的数据集')
     clearDatasetSelection()
-    await fetchDatasets()
+    await Promise.all([fetchDatasets(), fetchImportTasks(true)])
   } catch (error) {
     ElMessage.error(error?.response?.data?.message || '删除数据集失败')
   } finally {
@@ -380,7 +380,7 @@ const confirmDeleteDatasets = () => {
     return
   }
   ElMessageBox.confirm(
-    '删除后数据将无法恢复，且不会影响历史导入任务记录。是否继续？',
+    '删除后将同步清理对应的入库数据，并在导入任务记录中保留删除日志。是否继续？',
     '删除数据集',
     {
       confirmButtonText: '删除',


### PR DESCRIPTION
## Summary
- add multi-select support and a delete action for dataset rows in the data center view, including user confirmation
- expose a backend endpoint and service helper to remove dataset files when requested

## Testing
- npm run build
- mvn -f demo/pom.xml test *(fails: requires a database connection)*

------
https://chatgpt.com/codex/tasks/task_b_68f31133dbf4832c8f2ce6ff541699ef