### PR TITLE
Add admin user management page and backend support

### DIFF
--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/controller/UserController.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/controller/UserController.java
@@ -2,18 +2,26 @@ package com.gxj.cropyield.modules.auth.controller;
 
 import com.gxj.cropyield.common.response.ApiResponse;
 import com.gxj.cropyield.common.response.PageResponse;
+import com.gxj.cropyield.modules.auth.dto.RoleSummary;
+import com.gxj.cropyield.modules.auth.dto.UserPasswordRequest;
 import com.gxj.cropyield.modules.auth.dto.UserRequest;
 import com.gxj.cropyield.modules.auth.dto.UserResponse;
+import com.gxj.cropyield.modules.auth.dto.UserUpdateRequest;
 import com.gxj.cropyield.modules.auth.service.UserService;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/auth/users")
@@ -37,5 +45,33 @@ public class UserController {
     @PostMapping
     public ApiResponse<UserResponse> createUser(@Valid @RequestBody UserRequest request) {
         return ApiResponse.success(userService.createUser(request));
+    }
+
+    @PutMapping("/{id}")
+    public ApiResponse<UserResponse> updateUser(
+        @PathVariable("id") Long id,
+        @Valid @RequestBody UserUpdateRequest request
+    ) {
+        return ApiResponse.success(userService.updateUser(id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    public ApiResponse<Void> deleteUser(@PathVariable("id") Long id) {
+        userService.deleteUser(id);
+        return ApiResponse.success();
+    }
+
+    @PutMapping("/{id}/password")
+    public ApiResponse<Void> updatePassword(
+        @PathVariable("id") Long id,
+        @Valid @RequestBody UserPasswordRequest request
+    ) {
+        userService.updatePassword(id, request);
+        return ApiResponse.success();
+    }
+
+    @GetMapping("/roles")
+    public ApiResponse<List<RoleSummary>> listRoles() {
+        return ApiResponse.success(userService.listRoles());
     }
 }

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/RoleSummary.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/RoleSummary.java
@@ -1,0 +1,4 @@
+package com.gxj.cropyield.modules.auth.dto;
+
+public record RoleSummary(Long id, String code, String name) {
+}

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/UserPasswordRequest.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/UserPasswordRequest.java
@@ -1,0 +1,11 @@
+package com.gxj.cropyield.modules.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UserPasswordRequest(
+    @NotBlank(message = "新密码不能为空")
+    @Size(min = 6, max = 128, message = "密码长度需要在6-128位之间")
+    String newPassword
+) {
+}

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/UserResponse.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/UserResponse.java
@@ -8,7 +8,7 @@ public record UserResponse(
     String username,
     String fullName,
     String email,
-    Set<String> roles,
+    Set<RoleSummary> roles,
     LocalDateTime createdAt
 ) {
 }

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/UserUpdateRequest.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/UserUpdateRequest.java
@@ -1,0 +1,18 @@
+package com.gxj.cropyield.modules.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Size;
+
+import java.util.Set;
+
+public record UserUpdateRequest(
+    @Size(max = 128, message = "姓名长度不能超过128位")
+    String fullName,
+
+    @Email(message = "邮箱格式不正确")
+    @Size(max = 128, message = "邮箱长度不能超过128位")
+    String email,
+
+    Set<Long> roleIds
+) {
+}

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/service/UserService.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/service/UserService.java
@@ -1,13 +1,26 @@
 package com.gxj.cropyield.modules.auth.service;
 
+import com.gxj.cropyield.modules.auth.dto.RoleSummary;
+import com.gxj.cropyield.modules.auth.dto.UserPasswordRequest;
 import com.gxj.cropyield.modules.auth.dto.UserRequest;
 import com.gxj.cropyield.modules.auth.dto.UserResponse;
+import com.gxj.cropyield.modules.auth.dto.UserUpdateRequest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+
+import java.util.List;
 
 public interface UserService {
 
     Page<UserResponse> listUsers(Pageable pageable);
 
     UserResponse createUser(UserRequest request);
+
+    UserResponse updateUser(Long userId, UserUpdateRequest request);
+
+    void deleteUser(Long userId);
+
+    void updatePassword(Long userId, UserPasswordRequest request);
+
+    List<RoleSummary> listRoles();
 }

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/service/impl/UserServiceImpl.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/service/impl/UserServiceImpl.java
@@ -2,8 +2,11 @@ package com.gxj.cropyield.modules.auth.service.impl;
 
 import com.gxj.cropyield.common.exception.BusinessException;
 import com.gxj.cropyield.common.response.ResultCode;
+import com.gxj.cropyield.modules.auth.dto.RoleSummary;
+import com.gxj.cropyield.modules.auth.dto.UserPasswordRequest;
 import com.gxj.cropyield.modules.auth.dto.UserRequest;
 import com.gxj.cropyield.modules.auth.dto.UserResponse;
+import com.gxj.cropyield.modules.auth.dto.UserUpdateRequest;
 import com.gxj.cropyield.modules.auth.entity.Role;
 import com.gxj.cropyield.modules.auth.entity.User;
 import com.gxj.cropyield.modules.auth.repository.RoleRepository;
@@ -11,9 +14,13 @@ import com.gxj.cropyield.modules.auth.repository.UserRepository;
 import com.gxj.cropyield.modules.auth.service.UserService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -22,23 +29,19 @@ public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
     private final RoleRepository roleRepository;
+    private final PasswordEncoder passwordEncoder;
 
-    public UserServiceImpl(UserRepository userRepository, RoleRepository roleRepository) {
+    public UserServiceImpl(UserRepository userRepository, RoleRepository roleRepository, PasswordEncoder passwordEncoder) {
         this.userRepository = userRepository;
         this.roleRepository = roleRepository;
+        this.passwordEncoder = passwordEncoder;
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Page<UserResponse> listUsers(Pageable pageable) {
         return userRepository.findAll(pageable)
-            .map(user -> new UserResponse(
-                user.getId(),
-                user.getUsername(),
-                user.getFullName(),
-                user.getEmail(),
-                user.getRoles().stream().map(Role::getName).collect(Collectors.toSet()),
-                user.getCreatedAt()
-            ));
+            .map(this::toResponse);
     }
 
     @Override
@@ -51,23 +54,82 @@ public class UserServiceImpl implements UserService {
 
         User user = new User();
         user.setUsername(request.username());
-        user.setPassword(request.password());
+        user.setPassword(passwordEncoder.encode(request.password()));
         user.setFullName(request.fullName());
         user.setEmail(request.email());
+        user.setRoles(resolveRoles(request.roleIds()));
 
-        if (request.roleIds() != null && !request.roleIds().isEmpty()) {
-            Set<Role> roles = roleRepository.findAllById(request.roleIds()).stream().collect(Collectors.toSet());
-            user.setRoles(roles);
+        User saved = userRepository.save(user);
+        return toResponse(saved);
+    }
+
+    @Override
+    @Transactional
+    public UserResponse updateUser(Long userId, UserUpdateRequest request) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new BusinessException(ResultCode.NOT_FOUND, "用户不存在"));
+
+        if (request.fullName() != null) {
+            user.setFullName(request.fullName());
+        }
+        if (request.email() != null) {
+            user.setEmail(request.email());
+        }
+        if (request.roleIds() != null) {
+            user.setRoles(resolveRoles(request.roleIds()));
         }
 
         User saved = userRepository.save(user);
+        return toResponse(saved);
+    }
+
+    @Override
+    @Transactional
+    public void deleteUser(Long userId) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new BusinessException(ResultCode.NOT_FOUND, "用户不存在"));
+        userRepository.delete(user);
+    }
+
+    @Override
+    @Transactional
+    public void updatePassword(Long userId, UserPasswordRequest request) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new BusinessException(ResultCode.NOT_FOUND, "用户不存在"));
+        user.setPassword(passwordEncoder.encode(request.newPassword()));
+        userRepository.save(user);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<RoleSummary> listRoles() {
+        return roleRepository.findAll().stream()
+            .map(role -> new RoleSummary(role.getId(), role.getCode(), role.getName()))
+            .collect(Collectors.toList());
+    }
+
+    private Set<Role> resolveRoles(Set<Long> roleIds) {
+        if (roleIds == null || roleIds.isEmpty()) {
+            return new HashSet<>();
+        }
+        List<Role> roles = roleRepository.findAllById(roleIds);
+        if (roles.size() != roleIds.size()) {
+            throw new BusinessException(ResultCode.BAD_REQUEST, "存在无效的角色标识");
+        }
+        return new HashSet<>(roles);
+    }
+
+    private UserResponse toResponse(User user) {
+        Set<RoleSummary> roleSummaries = user.getRoles().stream()
+            .map(role -> new RoleSummary(role.getId(), role.getCode(), role.getName()))
+            .collect(Collectors.toCollection(LinkedHashSet::new));
         return new UserResponse(
-            saved.getId(),
-            saved.getUsername(),
-            saved.getFullName(),
-            saved.getEmail(),
-            saved.getRoles().stream().map(Role::getName).collect(Collectors.toSet()),
-            saved.getCreatedAt()
+            user.getId(),
+            user.getUsername(),
+            user.getFullName(),
+            user.getEmail(),
+            roleSummaries,
+            user.getCreatedAt()
         );
     }
 }

--- a/forecast/src/layouts/DefaultLayout.vue
+++ b/forecast/src/layouts/DefaultLayout.vue
@@ -18,6 +18,9 @@
         <el-menu-item index="/report" :route="{ name: 'report' }">
           <span>报告中心</span>
         </el-menu-item>
+        <el-menu-item index="/users" :route="{ name: 'users' }">
+          <span>用户管理</span>
+        </el-menu-item>
         <el-menu-item index="/settings" :route="{ name: 'settings' }">
           <span>系统设置</span>
         </el-menu-item>
@@ -56,6 +59,7 @@ const titles = {
   visualization: '数据可视化洞察',
   forecast: '预测建模与任务',
   report: '报告输出与分享',
+  users: '用户与部门管理',
   settings: '系统设置'
 }
 

--- a/forecast/src/router/index.js
+++ b/forecast/src/router/index.js
@@ -55,6 +55,12 @@ const routes = [
         meta: { requiresAuth: true, roles: ['ADMIN', 'AGRICULTURE_DEPT', 'FARMER'] }
       },
       {
+        path: 'users',
+        name: 'users',
+        component: () => import('../views/UserManagementView.vue'),
+        meta: { requiresAuth: true, roles: ['ADMIN'] }
+      },
+      {
         path: 'settings',
         name: 'settings',
         component: () => import('../views/SystemSettingView.vue'),

--- a/forecast/src/views/UserManagementView.vue
+++ b/forecast/src/views/UserManagementView.vue
@@ -1,0 +1,668 @@
+<template>
+  <div class="user-management-page">
+    <el-card class="intro-card" shadow="hover">
+      <div class="intro-content">
+        <div class="intro-text">
+          <div class="intro-badge">账户与权限中心</div>
+          <h1 class="intro-title">农业部门与用户统一管理</h1>
+          <p class="intro-desc">
+            集中维护农业部门及业务用户的基础信息，支持管理员快速分配角色、重置密码与停用账户，保障平台安全合规运行。
+          </p>
+          <div class="intro-highlights">
+            <div class="highlight-item">
+              <div class="highlight-value">{{ pagination.total }}</div>
+              <div class="highlight-label">已接入账户</div>
+            </div>
+            <div class="highlight-item">
+              <div class="highlight-value">{{ agricultureUserCount }}</div>
+              <div class="highlight-label">农业部门用户</div>
+            </div>
+            <div class="highlight-item">
+              <div class="highlight-value">{{ farmerUserCount }}</div>
+              <div class="highlight-label">企业/农户用户</div>
+            </div>
+          </div>
+        </div>
+        <div class="intro-side">
+          <div class="side-tip-title">操作建议</div>
+          <ul class="side-tip-list">
+            <li>定期核验角色配置，确保农业部门具备最新权限。</li>
+            <li>为临时账户设置到期提醒，按时回收使用权限。</li>
+            <li>重置密码后及时通知相关责任人完成首次登录。</li>
+          </ul>
+        </div>
+      </div>
+    </el-card>
+
+    <el-card class="table-card" shadow="hover">
+      <template #header>
+        <div class="table-header">
+          <div>
+            <div class="table-title">用户账户列表</div>
+            <div class="table-subtitle">查看与维护农业部门、企业/农户等平台用户的基础信息</div>
+          </div>
+          <div class="table-actions">
+            <el-button @click="fetchUsers" :loading="loading">刷新</el-button>
+            <el-button type="primary" @click="openCreateDialog">新增用户</el-button>
+          </div>
+        </div>
+      </template>
+
+      <el-table :data="users" v-loading="loading" empty-text="暂无用户数据" :header-cell-style="tableHeaderStyle">
+        <el-table-column prop="username" label="用户名" min-width="140" />
+        <el-table-column label="姓名" min-width="140">
+          <template #default="{ row }">
+            {{ row.fullName || '未填写' }}
+          </template>
+        </el-table-column>
+        <el-table-column label="邮箱" min-width="200">
+          <template #default="{ row }">
+            {{ row.email || '未绑定邮箱' }}
+          </template>
+        </el-table-column>
+        <el-table-column label="角色" min-width="220">
+          <template #default="{ row }">
+            <el-space wrap>
+              <el-tag v-for="role in row.roles" :key="role.id" type="success" effect="dark">
+                {{ formatRoleLabel(role) }}
+              </el-tag>
+            </el-space>
+          </template>
+        </el-table-column>
+        <el-table-column label="创建时间" width="200">
+          <template #default="{ row }">
+            {{ formatDateTime(row.createdAt) }}
+          </template>
+        </el-table-column>
+        <el-table-column label="操作" width="240" fixed="right">
+          <template #default="{ row }">
+            <el-button type="primary" text size="small" @click="openEditDialog(row)">编辑信息</el-button>
+            <el-button type="warning" text size="small" @click="openPasswordDialog(row)">重置密码</el-button>
+            <el-button
+              type="danger"
+              text
+              size="small"
+              :disabled="!canDelete(row)"
+              @click="confirmDelete(row)"
+            >
+              删除
+            </el-button>
+          </template>
+        </el-table-column>
+      </el-table>
+
+      <div class="table-footer">
+        <div class="table-tip">建议为农业部门及企业/农户分配匹配的角色权限，保障数据安全。</div>
+        <el-pagination
+          v-model:current-page="pagination.page"
+          v-model:page-size="pagination.size"
+          :page-sizes="[10, 20, 30, 50]"
+          layout="total, sizes, prev, pager, next"
+          :total="pagination.total"
+          background
+          @size-change="handleSizeChange"
+          @current-change="handlePageChange"
+        />
+      </div>
+    </el-card>
+
+    <el-dialog
+      v-model="editDialogVisible"
+      :title="isCreateMode ? '新增用户' : '编辑用户信息'"
+      width="560px"
+      :close-on-click-modal="false"
+    >
+      <el-form ref="editFormRef" :model="editForm" :rules="editRules" label-width="100px" status-icon>
+        <el-form-item label="用户名" prop="username">
+          <el-input v-model.trim="editForm.username" :disabled="isEditMode" placeholder="请输入用户名" />
+        </el-form-item>
+        <el-form-item v-if="isCreateMode" label="登录密码" prop="password">
+          <el-input v-model="editForm.password" type="password" show-password placeholder="请输入登录密码" />
+        </el-form-item>
+        <el-form-item label="姓名" prop="fullName">
+          <el-input v-model="editForm.fullName" placeholder="请输入姓名" />
+        </el-form-item>
+        <el-form-item label="邮箱" prop="email">
+          <el-input v-model.trim="editForm.email" placeholder="请输入邮箱地址" />
+        </el-form-item>
+        <el-form-item label="用户角色" prop="roleIds">
+          <el-select
+            v-model="editForm.roleIds"
+            multiple
+            filterable
+            placeholder="请选择角色"
+            class="full-width"
+            :loading="roleLoading"
+          >
+            <el-option
+              v-for="role in roleOptions"
+              :key="role.id"
+              :label="formatRoleLabel(role)"
+              :value="role.id"
+            />
+          </el-select>
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <span class="dialog-footer">
+          <el-button @click="editDialogVisible = false">取消</el-button>
+          <el-button type="primary" :loading="editSubmitting" @click="submitEditForm">
+            {{ isCreateMode ? '创建' : '保存' }}
+          </el-button>
+        </span>
+      </template>
+    </el-dialog>
+
+    <el-dialog
+      v-model="passwordDialogVisible"
+      title="重置用户密码"
+      width="480px"
+      :close-on-click-modal="false"
+    >
+      <el-form ref="passwordFormRef" :model="passwordForm" :rules="passwordRules" label-width="100px" status-icon>
+        <el-form-item label="用户名">
+          <el-input :model-value="passwordForm.username" disabled />
+        </el-form-item>
+        <el-form-item label="新密码" prop="newPassword">
+          <el-input v-model="passwordForm.newPassword" type="password" show-password placeholder="请输入新密码" />
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <span class="dialog-footer">
+          <el-button @click="passwordDialogVisible = false">取消</el-button>
+          <el-button type="primary" :loading="passwordSubmitting" @click="submitPasswordForm">确认重置</el-button>
+        </span>
+      </template>
+    </el-dialog>
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted, reactive, ref } from 'vue'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import apiClient from '../services/http'
+import { useAuthStore } from '../stores/auth'
+
+const users = ref([])
+const loading = ref(false)
+const pagination = reactive({ page: 1, size: 10, total: 0 })
+
+const roleOptions = ref([])
+const roleLoading = ref(false)
+
+const editDialogVisible = ref(false)
+const editDialogMode = ref('create')
+const editFormRef = ref()
+const editSubmitting = ref(false)
+const editForm = reactive({
+  id: null,
+  username: '',
+  password: '',
+  fullName: '',
+  email: '',
+  roleIds: []
+})
+
+const passwordDialogVisible = ref(false)
+const passwordFormRef = ref()
+const passwordSubmitting = ref(false)
+const passwordForm = reactive({
+  id: null,
+  username: '',
+  newPassword: ''
+})
+
+const authStore = useAuthStore()
+const currentUserId = computed(() => authStore.user?.id ?? null)
+
+const isCreateMode = computed(() => editDialogMode.value === 'create')
+const isEditMode = computed(() => editDialogMode.value === 'edit')
+
+const tableHeaderStyle = () => ({
+  backgroundColor: '#f5f7fa',
+  color: '#455a64',
+  fontWeight: 500
+})
+
+const formatDateTime = value => {
+  if (!value) {
+    return '-'
+  }
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return '-'
+  }
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')} ${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`
+}
+
+const formatRoleLabel = role => {
+  if (!role) {
+    return ''
+  }
+  if (role.name && role.code) {
+    return `${role.name}（${role.code}）`
+  }
+  return role.name || role.code || '未命名角色'
+}
+
+const sanitizeRoleIds = roleIds => {
+  if (!Array.isArray(roleIds)) {
+    return []
+  }
+  return roleIds
+    .map(id => Number(id))
+    .filter(id => Number.isInteger(id) && id > 0)
+}
+
+const normalizeOptional = value => {
+  if (value == null) {
+    return null
+  }
+  const trimmed = String(value).trim()
+  return trimmed.length ? trimmed : null
+}
+
+const fetchRoles = async () => {
+  roleLoading.value = true
+  try {
+    const { data } = await apiClient.get('/api/auth/users/roles')
+    roleOptions.value = Array.isArray(data?.data) ? data.data : []
+  } catch (error) {
+    ElMessage.error(error?.response?.data?.message || '获取角色信息失败')
+  } finally {
+    roleLoading.value = false
+  }
+}
+
+const fetchUsers = async () => {
+  loading.value = true
+  try {
+    const { data } = await apiClient.get('/api/auth/users', {
+      params: {
+        page: Math.max(pagination.page - 1, 0),
+        size: pagination.size
+      }
+    })
+    const response = data?.data
+    users.value = Array.isArray(response?.records) ? response.records : []
+    pagination.total = Number(response?.total ?? 0)
+    const currentPage = Number(response?.page ?? 0)
+    pagination.page = currentPage + 1
+    pagination.size = Number(response?.size ?? pagination.size)
+  } catch (error) {
+    ElMessage.error(error?.response?.data?.message || '获取用户列表失败')
+  } finally {
+    loading.value = false
+  }
+}
+
+const agricultureUserCount = computed(() =>
+  users.value.filter(user => Array.isArray(user?.roles) && user.roles.some(role => role.code === 'AGRICULTURE_DEPT')).length
+)
+
+const farmerUserCount = computed(() =>
+  users.value.filter(user => Array.isArray(user?.roles) && user.roles.some(role => role.code === 'FARMER')).length
+)
+
+const resetEditForm = () => {
+  editForm.id = null
+  editForm.username = ''
+  editForm.password = ''
+  editForm.fullName = ''
+  editForm.email = ''
+  editForm.roleIds = []
+}
+
+const openCreateDialog = () => {
+  editDialogMode.value = 'create'
+  resetEditForm()
+  if (!roleOptions.value.length) {
+    fetchRoles()
+  }
+  editDialogVisible.value = true
+}
+
+const openEditDialog = user => {
+  if (!user) {
+    return
+  }
+  editDialogMode.value = 'edit'
+  editForm.id = user.id ?? null
+  editForm.username = user.username ?? ''
+  editForm.password = ''
+  editForm.fullName = user.fullName ?? ''
+  editForm.email = user.email ?? ''
+  editForm.roleIds = Array.isArray(user.roles)
+    ? user.roles
+        .map(role => Number(role?.id))
+        .filter(id => Number.isInteger(id) && id > 0)
+    : []
+  if (!roleOptions.value.length) {
+    fetchRoles()
+  }
+  editDialogVisible.value = true
+}
+
+const openPasswordDialog = user => {
+  if (!user) {
+    return
+  }
+  passwordForm.id = user.id ?? null
+  passwordForm.username = user.username ?? ''
+  passwordForm.newPassword = ''
+  passwordDialogVisible.value = true
+}
+
+const canDelete = user => {
+  if (!user || user.id == null) {
+    return false
+  }
+  if (currentUserId.value != null && Number(user.id) === Number(currentUserId.value)) {
+    return false
+  }
+  return true
+}
+
+const handlePageChange = page => {
+  pagination.page = page
+  fetchUsers()
+}
+
+const handleSizeChange = size => {
+  pagination.size = size
+  pagination.page = 1
+  fetchUsers()
+}
+
+const validatePassword = (rule, value, callback) => {
+  if (!isCreateMode.value) {
+    callback()
+    return
+  }
+  const password = value == null ? '' : String(value)
+  if (!password.trim()) {
+    callback(new Error('请输入密码'))
+    return
+  }
+  if (password.length < 6 || password.length > 128) {
+    callback(new Error('密码长度需要在6-128个字符之间'))
+    return
+  }
+  callback()
+}
+
+const editRules = {
+  username: [
+    { required: true, message: '请输入用户名', trigger: 'blur' },
+    { min: 2, max: 64, message: '用户名长度需要在2-64个字符之间', trigger: 'blur' }
+  ],
+  password: [{ validator: validatePassword, trigger: 'blur' }],
+  fullName: [{ max: 128, message: '姓名长度不能超过128个字符', trigger: 'blur' }],
+  email: [{ type: 'email', message: '请输入正确的邮箱地址', trigger: 'blur' }],
+  roleIds: [{ type: 'array', required: true, message: '请至少选择一个角色', trigger: 'change' }]
+}
+
+const passwordRules = {
+  newPassword: [
+    { required: true, message: '请输入新密码', trigger: 'blur' },
+    { min: 6, max: 128, message: '密码长度需要在6-128个字符之间', trigger: 'blur' }
+  ]
+}
+
+const submitEditForm = async () => {
+  if (!editFormRef.value) {
+    return
+  }
+  try {
+    await editFormRef.value.validate()
+  } catch (error) {
+    return
+  }
+
+  editSubmitting.value = true
+  try {
+    if (isCreateMode.value) {
+      const payload = {
+        username: editForm.username.trim(),
+        password: editForm.password,
+        fullName: normalizeOptional(editForm.fullName),
+        email: normalizeOptional(editForm.email),
+        roleIds: sanitizeRoleIds(editForm.roleIds)
+      }
+      await apiClient.post('/api/auth/users', payload)
+      ElMessage.success('已创建新用户')
+    } else {
+      const payload = {
+        fullName: normalizeOptional(editForm.fullName),
+        email: normalizeOptional(editForm.email),
+        roleIds: sanitizeRoleIds(editForm.roleIds)
+      }
+      await apiClient.put(`/api/auth/users/${editForm.id}`, payload)
+      ElMessage.success('用户信息已更新')
+    }
+    editDialogVisible.value = false
+    await fetchUsers()
+  } catch (error) {
+    ElMessage.error(error?.response?.data?.message || (isCreateMode.value ? '创建用户失败' : '更新用户失败'))
+  } finally {
+    editSubmitting.value = false
+  }
+}
+
+const submitPasswordForm = async () => {
+  if (!passwordFormRef.value) {
+    return
+  }
+  try {
+    await passwordFormRef.value.validate()
+  } catch (error) {
+    return
+  }
+
+  passwordSubmitting.value = true
+  try {
+    await apiClient.put(`/api/auth/users/${passwordForm.id}/password`, {
+      newPassword: passwordForm.newPassword
+    })
+    ElMessage.success('密码已重置')
+    passwordDialogVisible.value = false
+  } catch (error) {
+    ElMessage.error(error?.response?.data?.message || '重置密码失败')
+  } finally {
+    passwordSubmitting.value = false
+  }
+}
+
+const confirmDelete = user => {
+  if (!canDelete(user)) {
+    return
+  }
+  ElMessageBox.confirm(
+    `确认删除用户「${user.username}」吗？删除后该账号将无法登录系统。`,
+    '删除用户',
+    {
+      confirmButtonText: '删除',
+      cancelButtonText: '取消',
+      type: 'warning'
+    }
+  )
+    .then(async () => {
+      try {
+        await apiClient.delete(`/api/auth/users/${user.id}`)
+        ElMessage.success('用户已删除')
+        if (users.value.length === 1 && pagination.page > 1) {
+          pagination.page -= 1
+        }
+        await fetchUsers()
+      } catch (error) {
+        ElMessage.error(error?.response?.data?.message || '删除用户失败')
+      }
+    })
+    .catch(() => {})
+}
+
+onMounted(async () => {
+  await Promise.all([fetchRoles(), fetchUsers()])
+})
+</script>
+
+<style scoped>
+.user-management-page {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.intro-card {
+  border: none;
+}
+
+.intro-content {
+  display: flex;
+  gap: 32px;
+  align-items: stretch;
+}
+
+.intro-text {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.intro-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #1b5e20;
+  background: rgba(27, 94, 32, 0.12);
+  border-radius: 999px;
+  padding: 6px 14px;
+  width: fit-content;
+}
+
+.intro-title {
+  font-size: 24px;
+  font-weight: 600;
+  color: #1f2d3d;
+  margin: 0;
+}
+
+.intro-desc {
+  margin: 0;
+  color: #546e7a;
+  line-height: 1.6;
+}
+
+.intro-highlights {
+  display: flex;
+  gap: 24px;
+}
+
+.highlight-item {
+  background: #f5f7fa;
+  border-radius: 12px;
+  padding: 16px 20px;
+  min-width: 160px;
+}
+
+.highlight-value {
+  font-size: 28px;
+  font-weight: 600;
+  color: #0d47a1;
+}
+
+.highlight-label {
+  margin-top: 6px;
+  font-size: 13px;
+  color: #607d8b;
+}
+
+.intro-side {
+  width: 280px;
+  background: linear-gradient(180deg, rgba(0, 121, 107, 0.14), rgba(0, 150, 136, 0.05));
+  border-radius: 16px;
+  padding: 20px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  color: #004d40;
+}
+
+.side-tip-title {
+  font-weight: 600;
+  font-size: 16px;
+}
+
+.side-tip-list {
+  padding-left: 18px;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.table-card {
+  border: none;
+}
+
+.table-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.table-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: #263238;
+}
+
+.table-subtitle {
+  margin-top: 4px;
+  color: #607d8b;
+  font-size: 13px;
+}
+
+.table-actions {
+  display: flex;
+  gap: 12px;
+}
+
+.table-footer {
+  margin-top: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.table-tip {
+  color: #546e7a;
+  font-size: 13px;
+}
+
+.full-width {
+  width: 100%;
+}
+
+@media (max-width: 1024px) {
+  .intro-content {
+    flex-direction: column;
+  }
+
+  .intro-side {
+    width: 100%;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-start;
+  }
+
+  .side-tip-list {
+    padding-left: 16px;
+  }
+}
+</style>


### PR DESCRIPTION
## Summary
- extend the authentication APIs with role listings plus user update, delete, and password reset endpoints, including new DTOs
- ensure created users store encoded passwords and return role metadata for management views
- add an admin-only user management page and navigation entry between the report center and system settings

## Testing
- ./mvnw -q test *(fails: database configuration is required in the test environment)*

------
https://chatgpt.com/codex/tasks/task_b_68f394216aec832c8ee4666650fa8055