### PR TITLE
docs: annotate backend java components

### DIFF
--- a/demo/src/main/java/com/gxj/cropyield/CropYieldApplication.java
+++ b/demo/src/main/java/com/gxj/cropyield/CropYieldApplication.java
@@ -4,6 +4,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+/**
+ * 系统应用的启动类，负责引导 Spring Boot 服务加载与运行。
+ */
 
 @SpringBootApplication
 @EntityScan(basePackages = "com.gxj.cropyield")

--- a/demo/src/main/java/com/gxj/cropyield/common/config/CorsConfig.java
+++ b/demo/src/main/java/com/gxj/cropyield/common/config/CorsConfig.java
@@ -7,6 +7,10 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
 
 import java.util.List;
+/**
+ * 全局配置模块的配置类，配置全局配置相关的基础设施与框架行为。
+ * <p>核心方法：corsFilter。</p>
+ */
 
 @Configuration
 public class CorsConfig {

--- a/demo/src/main/java/com/gxj/cropyield/common/config/JacksonConfig.java
+++ b/demo/src/main/java/com/gxj/cropyield/common/config/JacksonConfig.java
@@ -5,6 +5,10 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+/**
+ * 全局配置模块的配置类，配置全局配置相关的基础设施与框架行为。
+ * <p>核心方法：objectMapper。</p>
+ */
 
 @Configuration
 public class JacksonConfig {

--- a/demo/src/main/java/com/gxj/cropyield/common/config/JwtProperties.java
+++ b/demo/src/main/java/com/gxj/cropyield/common/config/JwtProperties.java
@@ -1,6 +1,10 @@
 package com.gxj.cropyield.common.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+/**
+ * 全局配置模块的配置类，配置全局配置相关的基础设施与框架行为。
+ * <p>核心方法：getSecret、setSecret、getExpiration、setExpiration、getRefreshExpiration、setRefreshExpiration。</p>
+ */
 
 @ConfigurationProperties(prefix = "security.jwt")
 public class JwtProperties {

--- a/demo/src/main/java/com/gxj/cropyield/common/exception/BusinessException.java
+++ b/demo/src/main/java/com/gxj/cropyield/common/exception/BusinessException.java
@@ -1,6 +1,9 @@
 package com.gxj.cropyield.common.exception;
 
 import com.gxj.cropyield.common.response.ResultCode;
+/**
+ * 统一异常模块的异常类，用于标识统一异常流程中的错误状态。
+ */
 
 public class BusinessException extends RuntimeException {
 

--- a/demo/src/main/java/com/gxj/cropyield/common/exception/GlobalExceptionHandler.java
+++ b/demo/src/main/java/com/gxj/cropyield/common/exception/GlobalExceptionHandler.java
@@ -10,6 +10,9 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.stream.Collectors;
+/**
+ * 统一异常模块的异常类，用于标识统一异常流程中的错误状态。
+ */
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {

--- a/demo/src/main/java/com/gxj/cropyield/common/logging/AuditLogger.java
+++ b/demo/src/main/java/com/gxj/cropyield/common/logging/AuditLogger.java
@@ -5,6 +5,9 @@ import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
+/**
+ * 审计日志模块的日志组件，记录审计日志的操作轨迹。
+ */
 
 @Component
 public class AuditLogger {

--- a/demo/src/main/java/com/gxj/cropyield/common/model/BaseEntity.java
+++ b/demo/src/main/java/com/gxj/cropyield/common/model/BaseEntity.java
@@ -9,6 +9,9 @@ import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 
 import java.time.LocalDateTime;
+/**
+ * 公共模型模块的实体类，映射公共模型领域对应的数据表结构。
+ */
 
 @MappedSuperclass
 public abstract class BaseEntity {

--- a/demo/src/main/java/com/gxj/cropyield/common/response/ApiResponse.java
+++ b/demo/src/main/java/com/gxj/cropyield/common/response/ApiResponse.java
@@ -1,6 +1,9 @@
 package com.gxj.cropyield.common.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+/**
+ * 通用响应模块的数据传输对象（记录类型），在通用响应场景下承载参数与返回值。
+ */
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record ApiResponse<T>(int code, String message, T data) {

--- a/demo/src/main/java/com/gxj/cropyield/common/response/PageResponse.java
+++ b/demo/src/main/java/com/gxj/cropyield/common/response/PageResponse.java
@@ -1,6 +1,9 @@
 package com.gxj.cropyield.common.response;
 
 import java.util.List;
+/**
+ * 通用响应模块的数据传输对象（记录类型），在通用响应场景下承载参数与返回值。
+ */
 
 public record PageResponse<T>(List<T> records, long total, int page, int size) {
 }

--- a/demo/src/main/java/com/gxj/cropyield/common/response/ResultCode.java
+++ b/demo/src/main/java/com/gxj/cropyield/common/response/ResultCode.java
@@ -1,4 +1,7 @@
 package com.gxj.cropyield.common.response;
+/**
+ * 通用响应模块的核心类（枚举），提供通用响应相关的支撑能力。
+ */
 
 public enum ResultCode {
     SUCCESS(0, "success"),

--- a/demo/src/main/java/com/gxj/cropyield/common/security/CustomUserDetailsService.java
+++ b/demo/src/main/java/com/gxj/cropyield/common/security/CustomUserDetailsService.java
@@ -11,6 +11,10 @@ import org.springframework.stereotype.Service;
 
 import java.util.Set;
 import java.util.stream.Collectors;
+/**
+ * 安全认证模块的业务接口，定义安全认证相关的核心业务操作。
+ * <p>核心方法：loadUserByUsername。</p>
+ */
 
 @Service
 public class CustomUserDetailsService implements UserDetailsService {

--- a/demo/src/main/java/com/gxj/cropyield/common/security/JwtAuthenticationFilter.java
+++ b/demo/src/main/java/com/gxj/cropyield/common/security/JwtAuthenticationFilter.java
@@ -14,6 +14,9 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+/**
+ * 安全认证模块的安全组件，处理安全认证的认证与授权逻辑。
+ */
 
 @Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {

--- a/demo/src/main/java/com/gxj/cropyield/common/security/JwtTokenProvider.java
+++ b/demo/src/main/java/com/gxj/cropyield/common/security/JwtTokenProvider.java
@@ -14,6 +14,9 @@ import java.util.Date;
 import java.util.stream.Collectors;
 
 import javax.crypto.SecretKey;
+/**
+ * 安全认证模块的安全组件，处理安全认证的认证与授权逻辑。
+ */
 
 @Component
 public class JwtTokenProvider {

--- a/demo/src/main/java/com/gxj/cropyield/config/ApplicationSecurityConfig.java
+++ b/demo/src/main/java/com/gxj/cropyield/config/ApplicationSecurityConfig.java
@@ -28,6 +28,10 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 import java.nio.charset.StandardCharsets;
 
+/**
+ * 全局配置模块的配置类，配置全局配置相关的基础设施与框架行为。
+ * <p>核心方法：passwordEncoder、authenticationProvider、authenticationManager、applicationSecurityFilterChain、writeErrorResponse、corsConfigurationSource。</p>
+ */
 @Configuration
 @EnableWebSecurity
 @EnableConfigurationProperties(JwtProperties.class)

--- a/demo/src/main/java/com/gxj/cropyield/config/AsyncConfig.java
+++ b/demo/src/main/java/com/gxj/cropyield/config/AsyncConfig.java
@@ -5,6 +5,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+/**
+ * 全局配置模块的配置类，配置全局配置相关的基础设施与框架行为。
+ * <p>核心方法：importTaskExecutor。</p>
+ */
 
 @Configuration
 @EnableAsync

--- a/demo/src/main/java/com/gxj/cropyield/config/WebConfig.java
+++ b/demo/src/main/java/com/gxj/cropyield/config/WebConfig.java
@@ -3,6 +3,10 @@ package com.gxj.cropyield.config;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+/**
+ * 全局配置模块的配置类，配置全局配置相关的基础设施与框架行为。
+ * <p>核心方法：addCorsMappings。</p>
+ */
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {

--- a/demo/src/main/java/com/gxj/cropyield/dashboard/DashboardController.java
+++ b/demo/src/main/java/com/gxj/cropyield/dashboard/DashboardController.java
@@ -4,6 +4,10 @@ import com.gxj.cropyield.dashboard.dto.DashboardSummaryResponse;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+/**
+ * 驾驶舱统计模块的控制器，用于暴露驾驶舱统计相关的 REST 接口。
+ * <p>核心方法：getSummary。</p>
+ */
 
 @RestController
 @RequestMapping("/api/dashboard")

--- a/demo/src/main/java/com/gxj/cropyield/dashboard/DashboardService.java
+++ b/demo/src/main/java/com/gxj/cropyield/dashboard/DashboardService.java
@@ -21,6 +21,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
+/**
+ * 驾驶舱统计模块的业务接口，定义驾驶舱统计相关的核心业务操作。
+ * <p>核心方法：getSummary、buildProductionTrend、buildCropStructure、buildRegionComparisons、buildRecentRecords、round、buildForecast、safe。</p>
+ */
 
 @Service
 public class DashboardService {

--- a/demo/src/main/java/com/gxj/cropyield/dashboard/dto/CropShare.java
+++ b/demo/src/main/java/com/gxj/cropyield/dashboard/dto/CropShare.java
@@ -1,4 +1,7 @@
 package com.gxj.cropyield.dashboard.dto;
+/**
+ * 驾驶舱统计模块的数据传输对象（记录类型），在驾驶舱统计场景下承载参数与返回值。
+ */
 
 public record CropShare(
         String cropName,

--- a/demo/src/main/java/com/gxj/cropyield/dashboard/dto/DashboardSummaryResponse.java
+++ b/demo/src/main/java/com/gxj/cropyield/dashboard/dto/DashboardSummaryResponse.java
@@ -1,6 +1,9 @@
 package com.gxj.cropyield.dashboard.dto;
 
 import java.util.List;
+/**
+ * 驾驶舱统计模块的数据传输对象（记录类型），在驾驶舱统计场景下承载参数与返回值。
+ */
 
 public record DashboardSummaryResponse(
         double totalProduction,

--- a/demo/src/main/java/com/gxj/cropyield/dashboard/dto/ForecastPoint.java
+++ b/demo/src/main/java/com/gxj/cropyield/dashboard/dto/ForecastPoint.java
@@ -1,4 +1,7 @@
 package com.gxj.cropyield.dashboard.dto;
+/**
+ * 驾驶舱统计模块的数据传输对象（记录类型），在驾驶舱统计场景下承载参数与返回值。
+ */
 
 public record ForecastPoint(
         String label,

--- a/demo/src/main/java/com/gxj/cropyield/dashboard/dto/RecentYieldRecord.java
+++ b/demo/src/main/java/com/gxj/cropyield/dashboard/dto/RecentYieldRecord.java
@@ -1,6 +1,9 @@
 package com.gxj.cropyield.dashboard.dto;
 
 import java.time.LocalDate;
+/**
+ * 驾驶舱统计模块的数据传输对象（记录类型），在驾驶舱统计场景下承载参数与返回值。
+ */
 
 public record RecentYieldRecord(
         Long runId,

--- a/demo/src/main/java/com/gxj/cropyield/dashboard/dto/RegionProductionSummary.java
+++ b/demo/src/main/java/com/gxj/cropyield/dashboard/dto/RegionProductionSummary.java
@@ -1,4 +1,7 @@
 package com.gxj.cropyield.dashboard.dto;
+/**
+ * 驾驶舱统计模块的数据传输对象（记录类型），在驾驶舱统计场景下承载参数与返回值。
+ */
 
 public record RegionProductionSummary(
         String regionName,

--- a/demo/src/main/java/com/gxj/cropyield/dashboard/dto/TrendPoint.java
+++ b/demo/src/main/java/com/gxj/cropyield/dashboard/dto/TrendPoint.java
@@ -1,4 +1,7 @@
 package com.gxj.cropyield.dashboard.dto;
+/**
+ * 驾驶舱统计模块的数据传输对象（记录类型），在驾驶舱统计场景下承载参数与返回值。
+ */
 
 public record TrendPoint(
         String label,

--- a/demo/src/main/java/com/gxj/cropyield/datamanagement/DataImportController.java
+++ b/demo/src/main/java/com/gxj/cropyield/datamanagement/DataImportController.java
@@ -18,6 +18,10 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
+/**
+ * 数据导入模块的控制器，用于暴露数据导入相关的 REST 接口。
+ * <p>核心方法：upload、listTasks、getTask、deleteTasks。</p>
+ */
 
 @RestController
 @RequestMapping("/api/data-import")

--- a/demo/src/main/java/com/gxj/cropyield/datamanagement/DataImportService.java
+++ b/demo/src/main/java/com/gxj/cropyield/datamanagement/DataImportService.java
@@ -71,6 +71,10 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+/**
+ * 数据导入模块的业务接口，定义数据导入相关的核心业务操作。
+ * <p>核心方法：deleteTasks、submitImport、mapToView、listJobs、getJobDetail、processJobAsync、ensureDatasetFile、updateDatasetFileMetadata。</p>
+ */
 
 @Service
 public class DataImportService {

--- a/demo/src/main/java/com/gxj/cropyield/datamanagement/dto/DataImportErrorView.java
+++ b/demo/src/main/java/com/gxj/cropyield/datamanagement/dto/DataImportErrorView.java
@@ -1,4 +1,7 @@
 package com.gxj.cropyield.datamanagement.dto;
+/**
+ * 数据导入模块的数据传输对象（记录类型），在数据导入场景下承载参数与返回值。
+ */
 
 public record DataImportErrorView(
         int rowNumber,

--- a/demo/src/main/java/com/gxj/cropyield/datamanagement/dto/DataImportJobDetailView.java
+++ b/demo/src/main/java/com/gxj/cropyield/datamanagement/dto/DataImportJobDetailView.java
@@ -3,6 +3,9 @@ package com.gxj.cropyield.datamanagement.dto;
 import com.gxj.cropyield.modules.dataset.dto.YieldRecordResponse;
 
 import java.util.List;
+/**
+ * 数据导入模块的数据传输对象（记录类型），在数据导入场景下承载参数与返回值。
+ */
 
 public record DataImportJobDetailView(
         DataImportJobView summary,

--- a/demo/src/main/java/com/gxj/cropyield/datamanagement/dto/DataImportJobPageResponse.java
+++ b/demo/src/main/java/com/gxj/cropyield/datamanagement/dto/DataImportJobPageResponse.java
@@ -1,6 +1,9 @@
 package com.gxj.cropyield.datamanagement.dto;
 
 import java.util.List;
+/**
+ * 数据导入模块的数据传输对象（记录类型），在数据导入场景下承载参数与返回值。
+ */
 
 public record DataImportJobPageResponse(
         List<DataImportJobView> content,

--- a/demo/src/main/java/com/gxj/cropyield/datamanagement/dto/DataImportJobView.java
+++ b/demo/src/main/java/com/gxj/cropyield/datamanagement/dto/DataImportJobView.java
@@ -4,6 +4,9 @@ import com.gxj.cropyield.datamanagement.model.DataImportJobStatus;
 import com.gxj.cropyield.modules.dataset.entity.DatasetFile.DatasetType;
 
 import java.time.LocalDateTime;
+/**
+ * 数据导入模块的数据传输对象（记录类型），在数据导入场景下承载参数与返回值。
+ */
 
 public record DataImportJobView(
         String taskId,

--- a/demo/src/main/java/com/gxj/cropyield/datamanagement/model/DataImportJob.java
+++ b/demo/src/main/java/com/gxj/cropyield/datamanagement/model/DataImportJob.java
@@ -22,6 +22,10 @@ import java.util.List;
         @Index(name = "idx_data_import_job_task", columnList = "task_id", unique = true),
         @Index(name = "idx_data_import_job_status", columnList = "status")
 })
+/**
+ * 数据导入模块的模型定义，描述数据导入领域的公共数据结构。
+ */
+
 public class DataImportJob extends BaseEntity {
 
     @Column(name = "task_id", nullable = false, length = 64, unique = true)

--- a/demo/src/main/java/com/gxj/cropyield/datamanagement/model/DataImportJobError.java
+++ b/demo/src/main/java/com/gxj/cropyield/datamanagement/model/DataImportJobError.java
@@ -7,6 +7,9 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+/**
+ * 数据导入模块的模型定义，描述数据导入领域的公共数据结构。
+ */
 
 @Entity
 @Table(name = "data_import_job_error")

--- a/demo/src/main/java/com/gxj/cropyield/datamanagement/model/DataImportJobStatus.java
+++ b/demo/src/main/java/com/gxj/cropyield/datamanagement/model/DataImportJobStatus.java
@@ -1,4 +1,7 @@
 package com.gxj.cropyield.datamanagement.model;
+/**
+ * 数据导入模块的模型定义（枚举），描述数据导入领域的公共数据结构。
+ */
 
 public enum DataImportJobStatus {
     QUEUED,

--- a/demo/src/main/java/com/gxj/cropyield/datamanagement/repository/DataImportJobErrorRepository.java
+++ b/demo/src/main/java/com/gxj/cropyield/datamanagement/repository/DataImportJobErrorRepository.java
@@ -4,6 +4,9 @@ import com.gxj.cropyield.datamanagement.model.DataImportJobError;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+/**
+ * 数据导入模块的数据访问接口（接口），封装了对数据导入相关数据表的持久化操作。
+ */
 
 public interface DataImportJobErrorRepository extends JpaRepository<DataImportJobError, Long> {
 

--- a/demo/src/main/java/com/gxj/cropyield/datamanagement/repository/DataImportJobRepository.java
+++ b/demo/src/main/java/com/gxj/cropyield/datamanagement/repository/DataImportJobRepository.java
@@ -7,6 +7,9 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+/**
+ * 数据导入模块的数据访问接口（接口），封装了对数据导入相关数据表的持久化操作。
+ */
 
 public interface DataImportJobRepository extends JpaRepository<DataImportJob, Long>, JpaSpecificationExecutor<DataImportJob> {
 

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/config/AuthDataInitializer.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/config/AuthDataInitializer.java
@@ -15,6 +15,10 @@ import org.springframework.stereotype.Component;
 import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
+/**
+ * 认证与账号模块的配置类，配置认证与账号相关的基础设施与框架行为。
+ * <p>核心方法：run、ensureExistingPasswordsEncrypted、isPasswordEncoded、ensureRole、refreshAdminAccount。</p>
+ */
 
 @Component
 public class AuthDataInitializer implements ApplicationRunner {

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/constant/SystemRole.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/constant/SystemRole.java
@@ -1,4 +1,7 @@
 package com.gxj.cropyield.modules.auth.constant;
+/**
+ * 认证与账号模块的核心类（枚举），提供认证与账号相关的支撑能力。
+ */
 
 public enum SystemRole {
     ADMIN("ADMIN", "系统管理员"),

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/controller/AuthController.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/controller/AuthController.java
@@ -20,6 +20,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+/**
+ * 认证与账号模块的控制器，用于暴露认证与账号相关的 REST 接口。
+ * <p>核心方法：captcha、register、login、adminLogin、userLogin、refreshToken、currentUser、checkPermission。</p>
+ */
 
 @RestController
 @RequestMapping("/api/auth")

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/controller/LoginLogController.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/controller/LoginLogController.java
@@ -23,6 +23,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDate;
+/**
+ * 认证与账号模块的控制器，用于暴露认证与账号相关的 REST 接口。
+ * <p>核心方法：list、summary、detail、create、update、delete。</p>
+ */
 
 @RestController
 @RequestMapping("/api/system/login-logs")

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/controller/ProfileController.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/controller/ProfileController.java
@@ -11,6 +11,10 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+/**
+ * 认证与账号模块的控制器，用于暴露认证与账号相关的 REST 接口。
+ * <p>核心方法：profile、updateProfile、changePassword。</p>
+ */
 
 @RestController
 @RequestMapping("/api/auth/profile")

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/controller/UserController.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/controller/UserController.java
@@ -22,6 +22,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+/**
+ * 认证与账号模块的控制器，用于暴露认证与账号相关的 REST 接口。
+ * <p>核心方法：listUsers、createUser、updateUser、deleteUser、updatePassword、listRoles。</p>
+ */
 
 @RestController
 @RequestMapping("/api/auth/users")

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/AuthTokens.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/AuthTokens.java
@@ -1,4 +1,7 @@
 package com.gxj.cropyield.modules.auth.dto;
+/**
+ * 认证与账号模块的数据传输对象（记录类型），在认证与账号场景下承载参数与返回值。
+ */
 
 public record AuthTokens(
     String accessToken,

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/CaptchaResponse.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/CaptchaResponse.java
@@ -1,4 +1,7 @@
 package com.gxj.cropyield.modules.auth.dto;
+/**
+ * 认证与账号模块的数据传输对象（记录类型），在认证与账号场景下承载参数与返回值。
+ */
 
 public record CaptchaResponse(
     String captchaId,

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/LoginLogQuery.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/LoginLogQuery.java
@@ -1,6 +1,9 @@
 package com.gxj.cropyield.modules.auth.dto;
 
 import java.time.LocalDate;
+/**
+ * 认证与账号模块的数据传输对象（记录类型），在认证与账号场景下承载参数与返回值。
+ */
 
 public record LoginLogQuery(
     String username,

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/LoginLogRequest.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/LoginLogRequest.java
@@ -3,6 +3,9 @@ package com.gxj.cropyield.modules.auth.dto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+/**
+ * 认证与账号模块的数据传输对象（记录类型），在认证与账号场景下承载参数与返回值。
+ */
 
 public record LoginLogRequest(
     @NotBlank(message = "请输入用户名")

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/LoginLogResponse.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/LoginLogResponse.java
@@ -3,6 +3,9 @@ package com.gxj.cropyield.modules.auth.dto;
 import com.gxj.cropyield.modules.auth.entity.LoginLog;
 
 import java.time.LocalDateTime;
+/**
+ * 认证与账号模块的数据传输对象（记录类型），在认证与账号场景下承载参数与返回值。
+ */
 
 public record LoginLogResponse(
     Long id,

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/LoginLogSummaryResponse.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/LoginLogSummaryResponse.java
@@ -1,6 +1,9 @@
 package com.gxj.cropyield.modules.auth.dto;
 
 import java.time.LocalDateTime;
+/**
+ * 认证与账号模块的数据传输对象（记录类型），在认证与账号场景下承载参数与返回值。
+ */
 
 public record LoginLogSummaryResponse(
     long totalCount,

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/LoginRequest.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/LoginRequest.java
@@ -1,6 +1,9 @@
 package com.gxj.cropyield.modules.auth.dto;
 
 import jakarta.validation.constraints.NotBlank;
+/**
+ * 认证与账号模块的数据传输对象（记录类型），在认证与账号场景下承载参数与返回值。
+ */
 
 public record LoginRequest(
     @NotBlank(message = "用户名不能为空")

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/LoginResponse.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/LoginResponse.java
@@ -1,4 +1,7 @@
 package com.gxj.cropyield.modules.auth.dto;
+/**
+ * 认证与账号模块的数据传输对象（记录类型），在认证与账号场景下承载参数与返回值。
+ */
 
 public record LoginResponse(
     AuthTokens tokens,

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/ProfilePasswordRequest.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/ProfilePasswordRequest.java
@@ -2,6 +2,9 @@ package com.gxj.cropyield.modules.auth.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+/**
+ * 认证与账号模块的数据传输对象（记录类型），在认证与账号场景下承载参数与返回值。
+ */
 
 public record ProfilePasswordRequest(
     @NotBlank(message = "当前密码不能为空")

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/ProfileResponse.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/ProfileResponse.java
@@ -2,6 +2,9 @@ package com.gxj.cropyield.modules.auth.dto;
 
 import java.time.LocalDateTime;
 import java.util.Set;
+/**
+ * 认证与账号模块的数据传输对象（记录类型），在认证与账号场景下承载参数与返回值。
+ */
 
 public record ProfileResponse(
     Long id,

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/ProfileUpdateRequest.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/ProfileUpdateRequest.java
@@ -2,6 +2,9 @@ package com.gxj.cropyield.modules.auth.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Size;
+/**
+ * 认证与账号模块的数据传输对象（记录类型），在认证与账号场景下承载参数与返回值。
+ */
 
 public record ProfileUpdateRequest(
     @Size(max = 128, message = "姓名长度不能超过128个字符")

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/RefreshTokenRequest.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/RefreshTokenRequest.java
@@ -1,6 +1,9 @@
 package com.gxj.cropyield.modules.auth.dto;
 
 import jakarta.validation.constraints.NotBlank;
+/**
+ * 认证与账号模块的数据传输对象（记录类型），在认证与账号场景下承载参数与返回值。
+ */
 
 public record RefreshTokenRequest(
     @NotBlank(message = "刷新令牌不能为空")

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/RegisterRequest.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/RegisterRequest.java
@@ -3,6 +3,9 @@ package com.gxj.cropyield.modules.auth.dto;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+/**
+ * 认证与账号模块的数据传输对象（记录类型），在认证与账号场景下承载参数与返回值。
+ */
 
 public record RegisterRequest(
     @NotBlank(message = "用户名不能为空")

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/ResetPasswordRequest.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/ResetPasswordRequest.java
@@ -2,6 +2,9 @@ package com.gxj.cropyield.modules.auth.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+/**
+ * 认证与账号模块的数据传输对象（记录类型），在认证与账号场景下承载参数与返回值。
+ */
 
 public record ResetPasswordRequest(
     @NotBlank(message = "旧密码不能为空")

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/RoleSummary.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/RoleSummary.java
@@ -1,4 +1,7 @@
 package com.gxj.cropyield.modules.auth.dto;
+/**
+ * 认证与账号模块的数据传输对象（记录类型），在认证与账号场景下承载参数与返回值。
+ */
 
 public record RoleSummary(Long id, String code, String name) {
 }

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/UserInfo.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/UserInfo.java
@@ -1,6 +1,9 @@
 package com.gxj.cropyield.modules.auth.dto;
 
 import java.util.Set;
+/**
+ * 认证与账号模块的数据传输对象（记录类型），在认证与账号场景下承载参数与返回值。
+ */
 
 public record UserInfo(
     Long id,

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/UserPasswordRequest.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/UserPasswordRequest.java
@@ -2,6 +2,9 @@ package com.gxj.cropyield.modules.auth.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+/**
+ * 认证与账号模块的数据传输对象（记录类型），在认证与账号场景下承载参数与返回值。
+ */
 
 public record UserPasswordRequest(
     @NotBlank(message = "新密码不能为空")

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/UserRequest.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/UserRequest.java
@@ -5,6 +5,9 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 import java.util.Set;
+/**
+ * 认证与账号模块的数据传输对象（记录类型），在认证与账号场景下承载参数与返回值。
+ */
 
 public record UserRequest(
     @NotBlank(message = "用户名不能为空")

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/UserResponse.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/UserResponse.java
@@ -2,6 +2,9 @@ package com.gxj.cropyield.modules.auth.dto;
 
 import java.time.LocalDateTime;
 import java.util.Set;
+/**
+ * 认证与账号模块的数据传输对象（记录类型），在认证与账号场景下承载参数与返回值。
+ */
 
 public record UserResponse(
     Long id,

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/UserUpdateRequest.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/dto/UserUpdateRequest.java
@@ -4,6 +4,9 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Size;
 
 import java.util.Set;
+/**
+ * 认证与账号模块的数据传输对象（记录类型），在认证与账号场景下承载参数与返回值。
+ */
 
 public record UserUpdateRequest(
     @Size(max = 128, message = "姓名长度不能超过128位")

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/entity/LoginLog.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/entity/LoginLog.java
@@ -4,6 +4,9 @@ import com.gxj.cropyield.common.model.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+/**
+ * 认证与账号模块的实体类，映射认证与账号领域对应的数据表结构。
+ */
 
 @Entity
 @Table(name = "sys_login_log")

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/entity/Permission.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/entity/Permission.java
@@ -4,6 +4,9 @@ import com.gxj.cropyield.common.model.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+/**
+ * 认证与账号模块的实体类，映射认证与账号领域对应的数据表结构。
+ */
 
 @Entity
 @Table(name = "sys_permission")

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/entity/RefreshToken.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/entity/RefreshToken.java
@@ -9,6 +9,9 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
 import java.time.LocalDateTime;
+/**
+ * 认证与账号模块的实体类，映射认证与账号领域对应的数据表结构。
+ */
 
 @Entity
 @Table(name = "sys_refresh_token")

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/entity/Role.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/entity/Role.java
@@ -5,6 +5,9 @@ import jakarta.persistence.*;
 
 import java.util.HashSet;
 import java.util.Set;
+/**
+ * 认证与账号模块的实体类，映射认证与账号领域对应的数据表结构。
+ */
 
 @Entity
 @Table(name = "sys_role")

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/entity/User.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/entity/User.java
@@ -5,6 +5,9 @@ import jakarta.persistence.*;
 
 import java.util.HashSet;
 import java.util.Set;
+/**
+ * 认证与账号模块的实体类，映射认证与账号领域对应的数据表结构。
+ */
 
 @Entity
 @Table(name = "sys_user")

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/repository/LoginLogRepository.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/repository/LoginLogRepository.java
@@ -5,6 +5,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import java.util.Optional;
+/**
+ * 认证与账号模块的数据访问接口（接口），封装了对认证与账号相关数据表的持久化操作。
+ */
 
 public interface LoginLogRepository extends JpaRepository<LoginLog, Long>, JpaSpecificationExecutor<LoginLog> {
 

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/repository/PermissionRepository.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/repository/PermissionRepository.java
@@ -2,6 +2,9 @@ package com.gxj.cropyield.modules.auth.repository;
 
 import com.gxj.cropyield.modules.auth.entity.Permission;
 import org.springframework.data.jpa.repository.JpaRepository;
+/**
+ * 认证与账号模块的数据访问接口（接口），封装了对认证与账号相关数据表的持久化操作。
+ */
 
 public interface PermissionRepository extends JpaRepository<Permission, Long> {
 }

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/repository/RefreshTokenRepository.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/repository/RefreshTokenRepository.java
@@ -5,6 +5,9 @@ import com.gxj.cropyield.modules.auth.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+/**
+ * 认证与账号模块的数据访问接口（接口），封装了对认证与账号相关数据表的持久化操作。
+ */
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/repository/RoleRepository.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/repository/RoleRepository.java
@@ -4,6 +4,9 @@ import com.gxj.cropyield.modules.auth.entity.Role;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+/**
+ * 认证与账号模块的数据访问接口（接口），封装了对认证与账号相关数据表的持久化操作。
+ */
 
 public interface RoleRepository extends JpaRepository<Role, Long> {
     Optional<Role> findByCode(String code);

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/repository/UserRepository.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/repository/UserRepository.java
@@ -5,6 +5,9 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+/**
+ * 认证与账号模块的数据访问接口（接口），封装了对认证与账号相关数据表的持久化操作。
+ */
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/service/AuthService.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/service/AuthService.java
@@ -5,6 +5,10 @@ import com.gxj.cropyield.modules.auth.dto.LoginRequest;
 import com.gxj.cropyield.modules.auth.dto.LoginResponse;
 import com.gxj.cropyield.modules.auth.dto.RegisterRequest;
 import com.gxj.cropyield.modules.auth.dto.UserInfo;
+/**
+ * 认证与账号模块的业务接口（接口），定义认证与账号相关的核心业务操作。
+ * <p>核心方法：login、loginAsAdmin、loginAsUser、register、refreshToken、getCurrentUser、hasRole。</p>
+ */
 
 public interface AuthService {
 

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/service/CaptchaService.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/service/CaptchaService.java
@@ -1,6 +1,10 @@
 package com.gxj.cropyield.modules.auth.service;
 
 import com.gxj.cropyield.modules.auth.dto.CaptchaResponse;
+/**
+ * 认证与账号模块的业务接口（接口），定义认证与账号相关的核心业务操作。
+ * <p>核心方法：createCaptcha、validate。</p>
+ */
 
 public interface CaptchaService {
 

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/service/LoginLogService.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/service/LoginLogService.java
@@ -7,6 +7,10 @@ import com.gxj.cropyield.modules.auth.dto.LoginLogSummaryResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+/**
+ * 认证与账号模块的业务接口（接口），定义认证与账号相关的核心业务操作。
+ * <p>核心方法：record、search、get、create、update、delete、summarize。</p>
+ */
 public interface LoginLogService {
 
     void record(String username, boolean success, String ipAddress, String userAgent, String message);

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/service/ProfileService.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/service/ProfileService.java
@@ -3,6 +3,10 @@ package com.gxj.cropyield.modules.auth.service;
 import com.gxj.cropyield.modules.auth.dto.ProfilePasswordRequest;
 import com.gxj.cropyield.modules.auth.dto.ProfileResponse;
 import com.gxj.cropyield.modules.auth.dto.ProfileUpdateRequest;
+/**
+ * 认证与账号模块的业务接口（接口），定义认证与账号相关的核心业务操作。
+ * <p>核心方法：getCurrentProfile、updateProfile、changePassword。</p>
+ */
 
 public interface ProfileService {
 

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/service/RefreshTokenService.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/service/RefreshTokenService.java
@@ -2,6 +2,10 @@ package com.gxj.cropyield.modules.auth.service;
 
 import com.gxj.cropyield.modules.auth.entity.RefreshToken;
 import com.gxj.cropyield.modules.auth.entity.User;
+/**
+ * 认证与账号模块的业务接口（接口），定义认证与账号相关的核心业务操作。
+ * <p>核心方法：create、validate、rotate。</p>
+ */
 
 public interface RefreshTokenService {
 

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/service/UserService.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/service/UserService.java
@@ -9,6 +9,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+/**
+ * 认证与账号模块的业务接口（接口），定义认证与账号相关的核心业务操作。
+ * <p>核心方法：listUsers、createUser、updateUser、deleteUser、updatePassword、listRoles。</p>
+ */
 
 public interface UserService {
 

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/service/impl/AuthServiceImpl.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/service/impl/AuthServiceImpl.java
@@ -33,6 +33,10 @@ import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
+/**
+ * 认证与账号模块的业务实现类，负责落实认证与账号领域的业务处理逻辑。
+ * <p>核心方法：login、performLogin、loginAsAdmin、loginAsUser、register、refreshToken、buildTokens、getCurrentUser。</p>
+ */
 
 @Service
 public class AuthServiceImpl implements AuthService {

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/service/impl/CaptchaServiceImpl.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/service/impl/CaptchaServiceImpl.java
@@ -17,6 +17,10 @@ import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+/**
+ * 认证与账号模块的业务实现类，负责落实认证与账号领域的业务处理逻辑。
+ * <p>核心方法：createCaptcha、validate、cleanupExpired、generateCaptcha、switch、generateAddition、generateSubtraction、generateMultiplication。</p>
+ */
 
 @Service
 public class CaptchaServiceImpl implements CaptchaService {

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/service/impl/LoginLogServiceImpl.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/service/impl/LoginLogServiceImpl.java
@@ -27,6 +27,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * 认证与账号模块的业务实现类，负责落实认证与账号领域的业务处理逻辑。
+ * <p>核心方法：record、search、get、create、update、delete、BusinessException、summarize。</p>
+ */
 @Service
 public class LoginLogServiceImpl implements LoginLogService {
 

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/service/impl/ProfileServiceImpl.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/service/impl/ProfileServiceImpl.java
@@ -21,6 +21,10 @@ import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
+/**
+ * 认证与账号模块的业务实现类，负责落实认证与账号领域的业务处理逻辑。
+ * <p>核心方法：getCurrentProfile、toResponse、updateProfile、changePassword、loadCurrentUser。</p>
+ */
 
 @Service
 public class ProfileServiceImpl implements ProfileService {

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/service/impl/RefreshTokenServiceImpl.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/service/impl/RefreshTokenServiceImpl.java
@@ -13,6 +13,10 @@ import org.springframework.transaction.annotation.Transactional;
 import java.security.SecureRandom;
 import java.time.LocalDateTime;
 import java.util.Base64;
+/**
+ * 认证与账号模块的业务实现类，负责落实认证与账号领域的业务处理逻辑。
+ * <p>核心方法：create、validate、rotate、calculateExpiry、generateTokenValue。</p>
+ */
 
 @Service
 public class RefreshTokenServiceImpl implements RefreshTokenService {

--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/service/impl/UserServiceImpl.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/service/impl/UserServiceImpl.java
@@ -23,6 +23,10 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+/**
+ * 认证与账号模块的业务实现类，负责落实认证与账号领域的业务处理逻辑。
+ * <p>核心方法：listUsers、createUser、toResponse、updateUser、deleteUser、updatePassword、listRoles、resolveRoles。</p>
+ */
 
 @Service
 public class UserServiceImpl implements UserService {

--- a/demo/src/main/java/com/gxj/cropyield/modules/base/controller/CropController.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/base/controller/CropController.java
@@ -12,6 +12,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+/**
+ * 基础数据模块的控制器，用于暴露基础数据相关的 REST 接口。
+ * <p>核心方法：listCrops、createCrop。</p>
+ */
 
 @RestController
 @RequestMapping("/api/base/crops")

--- a/demo/src/main/java/com/gxj/cropyield/modules/base/controller/RegionController.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/base/controller/RegionController.java
@@ -8,6 +8,10 @@ import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+/**
+ * 基础数据模块的控制器，用于暴露基础数据相关的 REST 接口。
+ * <p>核心方法：listRegions、createRegion、updateRegion、deleteRegion。</p>
+ */
 
 @RestController
 @RequestMapping("/api/base/regions")

--- a/demo/src/main/java/com/gxj/cropyield/modules/base/dto/CropRequest.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/base/dto/CropRequest.java
@@ -2,6 +2,9 @@ package com.gxj.cropyield.modules.base.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+/**
+ * 基础数据模块的数据传输对象（记录类型），在基础数据场景下承载参数与返回值。
+ */
 
 public record CropRequest(
     @NotBlank(message = "作物编码不能为空")

--- a/demo/src/main/java/com/gxj/cropyield/modules/base/dto/RegionRequest.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/base/dto/RegionRequest.java
@@ -1,6 +1,9 @@
 package com.gxj.cropyield.modules.base.dto;
 
 import jakarta.validation.constraints.Size;
+/**
+ * 基础数据模块的数据传输对象（记录类型），在基础数据场景下承载参数与返回值。
+ */
 
 public record RegionRequest(
     @Size(max = 64, message = "编码长度不能超过64位")

--- a/demo/src/main/java/com/gxj/cropyield/modules/base/entity/Crop.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/base/entity/Crop.java
@@ -4,6 +4,9 @@ import com.gxj.cropyield.common.model.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+/**
+ * 基础数据模块的实体类，映射基础数据领域对应的数据表结构。
+ */
 
 @Entity
 @Table(name = "base_crop")

--- a/demo/src/main/java/com/gxj/cropyield/modules/base/entity/Region.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/base/entity/Region.java
@@ -4,6 +4,9 @@ import com.gxj.cropyield.common.model.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+/**
+ * 基础数据模块的实体类，映射基础数据领域对应的数据表结构。
+ */
 
 @Entity
 @Table(name = "base_region")

--- a/demo/src/main/java/com/gxj/cropyield/modules/base/repository/CropRepository.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/base/repository/CropRepository.java
@@ -5,6 +5,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
+/**
+ * 基础数据模块的数据访问接口（接口），封装了对基础数据相关数据表的持久化操作。
+ */
 
 @Repository("cropyieldCropRepository")
 public interface CropRepository extends JpaRepository<Crop, Long> {

--- a/demo/src/main/java/com/gxj/cropyield/modules/base/repository/RegionRepository.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/base/repository/RegionRepository.java
@@ -5,6 +5,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
+/**
+ * 基础数据模块的数据访问接口（接口），封装了对基础数据相关数据表的持久化操作。
+ */
 
 @Repository("cropyieldRegionRepository")
 public interface RegionRepository extends JpaRepository<Region, Long> {

--- a/demo/src/main/java/com/gxj/cropyield/modules/base/service/CropService.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/base/service/CropService.java
@@ -4,6 +4,10 @@ import com.gxj.cropyield.modules.base.dto.CropRequest;
 import com.gxj.cropyield.modules.base.entity.Crop;
 
 import java.util.List;
+/**
+ * 基础数据模块的业务接口（接口），定义基础数据相关的核心业务操作。
+ * <p>核心方法：listAll、create。</p>
+ */
 
 public interface CropService {
 

--- a/demo/src/main/java/com/gxj/cropyield/modules/base/service/RegionService.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/base/service/RegionService.java
@@ -4,6 +4,10 @@ import com.gxj.cropyield.modules.base.dto.RegionRequest;
 import com.gxj.cropyield.modules.base.entity.Region;
 
 import java.util.List;
+/**
+ * 基础数据模块的业务接口（接口），定义基础数据相关的核心业务操作。
+ * <p>核心方法：listAll、create、update、delete。</p>
+ */
 
 public interface RegionService {
 

--- a/demo/src/main/java/com/gxj/cropyield/modules/base/service/impl/CropServiceImpl.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/base/service/impl/CropServiceImpl.java
@@ -10,6 +10,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+/**
+ * 基础数据模块的业务实现类，负责落实基础数据领域的业务处理逻辑。
+ * <p>核心方法：listAll、create。</p>
+ */
 
 @Service
 public class CropServiceImpl implements CropService {

--- a/demo/src/main/java/com/gxj/cropyield/modules/base/service/impl/RegionServiceImpl.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/base/service/impl/RegionServiceImpl.java
@@ -20,6 +20,10 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Pattern;
+/**
+ * 基础数据模块的业务实现类，负责落实基础数据领域的业务处理逻辑。
+ * <p>核心方法：listAll、create、update、delete、applyRequest、ensureNameUnique、resolveCode、ensureUniqueCode。</p>
+ */
 
 @Service
 public class RegionServiceImpl implements RegionService {

--- a/demo/src/main/java/com/gxj/cropyield/modules/dataset/config/DatasetSchemaMigrator.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/dataset/config/DatasetSchemaMigrator.java
@@ -7,6 +7,10 @@ import org.springframework.boot.ApplicationRunner;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
+/**
+ * 数据集管理模块的配置类，配置数据集管理相关的基础设施与框架行为。
+ * <p>核心方法：run、ensureDatasetFileColumn、ensureImportJobColumn、columnExists、indexExists、foreignKeyExists、executeDdl。</p>
+ */
 
 @Component
 public class DatasetSchemaMigrator implements ApplicationRunner {

--- a/demo/src/main/java/com/gxj/cropyield/modules/dataset/controller/DatasetFileController.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/dataset/controller/DatasetFileController.java
@@ -13,6 +13,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+/**
+ * 数据集管理模块的控制器，用于暴露数据集管理相关的 REST 接口。
+ * <p>核心方法：listFiles、createFile、deleteFiles。</p>
+ */
 
 @RestController
 @RequestMapping("/api/datasets/files")

--- a/demo/src/main/java/com/gxj/cropyield/modules/dataset/controller/PriceRecordController.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/dataset/controller/PriceRecordController.java
@@ -12,6 +12,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+/**
+ * 数据集管理模块的控制器，用于暴露数据集管理相关的 REST 接口。
+ * <p>核心方法：listRecords、createRecord。</p>
+ */
 
 @RestController
 @RequestMapping("/api/datasets/price-records")

--- a/demo/src/main/java/com/gxj/cropyield/modules/dataset/controller/YieldRecordController.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/dataset/controller/YieldRecordController.java
@@ -12,6 +12,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+/**
+ * 数据集管理模块的控制器，用于暴露数据集管理相关的 REST 接口。
+ * <p>核心方法：listRecords、createRecord。</p>
+ */
 
 @RestController
 @RequestMapping("/api/datasets/yield-records")

--- a/demo/src/main/java/com/gxj/cropyield/modules/dataset/dto/DatasetFileRequest.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/dataset/dto/DatasetFileRequest.java
@@ -4,6 +4,9 @@ import com.gxj.cropyield.modules.dataset.entity.DatasetFile.DatasetType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+/**
+ * 数据集管理模块的数据传输对象（记录类型），在数据集管理场景下承载参数与返回值。
+ */
 
 public record DatasetFileRequest(
     @NotBlank(message = "数据集名称不能为空")

--- a/demo/src/main/java/com/gxj/cropyield/modules/dataset/dto/PriceRecordRequest.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/dataset/dto/PriceRecordRequest.java
@@ -3,6 +3,9 @@ package com.gxj.cropyield.modules.dataset.dto;
 import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDate;
+/**
+ * 数据集管理模块的数据传输对象（记录类型），在数据集管理场景下承载参数与返回值。
+ */
 
 public record PriceRecordRequest(
     @NotNull(message = "作物ID不能为空")

--- a/demo/src/main/java/com/gxj/cropyield/modules/dataset/dto/YieldRecordDetailView.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/dataset/dto/YieldRecordDetailView.java
@@ -2,6 +2,9 @@ package com.gxj.cropyield.modules.dataset.dto;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+/**
+ * 数据集管理模块的数据传输对象（记录类型），在数据集管理场景下承载参数与返回值。
+ */
 
 public record YieldRecordDetailView(
         Long id,

--- a/demo/src/main/java/com/gxj/cropyield/modules/dataset/dto/YieldRecordRequest.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/dataset/dto/YieldRecordRequest.java
@@ -4,6 +4,9 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDate;
+/**
+ * 数据集管理模块的数据传输对象（记录类型），在数据集管理场景下承载参数与返回值。
+ */
 
 public record YieldRecordRequest(
     @NotNull(message = "作物ID不能为空")

--- a/demo/src/main/java/com/gxj/cropyield/modules/dataset/dto/YieldRecordResponse.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/dataset/dto/YieldRecordResponse.java
@@ -1,6 +1,9 @@
 package com.gxj.cropyield.modules.dataset.dto;
 
 import java.time.LocalDate;
+/**
+ * 数据集管理模块的数据传输对象（记录类型），在数据集管理场景下承载参数与返回值。
+ */
 
 public record YieldRecordResponse(
         Long id,

--- a/demo/src/main/java/com/gxj/cropyield/modules/dataset/entity/DatasetFile.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/dataset/entity/DatasetFile.java
@@ -6,6 +6,9 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
+/**
+ * 数据集管理模块的实体类，映射数据集管理领域对应的数据表结构。
+ */
 
 @Entity
 @Table(name = "dataset_file")

--- a/demo/src/main/java/com/gxj/cropyield/modules/dataset/entity/PriceRecord.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/dataset/entity/PriceRecord.java
@@ -12,6 +12,9 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
 import java.time.LocalDate;
+/**
+ * 数据集管理模块的实体类，映射数据集管理领域对应的数据表结构。
+ */
 
 @Entity
 @Table(name = "dataset_price_record")

--- a/demo/src/main/java/com/gxj/cropyield/modules/dataset/entity/YieldRecord.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/dataset/entity/YieldRecord.java
@@ -10,6 +10,9 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+/**
+ * 数据集管理模块的实体类，映射数据集管理领域对应的数据表结构。
+ */
 
 @Entity
 @Table(name = "dataset_yield_record")

--- a/demo/src/main/java/com/gxj/cropyield/modules/dataset/repository/DatasetFileRepository.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/dataset/repository/DatasetFileRepository.java
@@ -4,6 +4,9 @@ import com.gxj.cropyield.modules.dataset.entity.DatasetFile;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+/**
+ * 数据集管理模块的数据访问接口（接口），封装了对数据集管理相关数据表的持久化操作。
+ */
 
 public interface DatasetFileRepository extends JpaRepository<DatasetFile, Long> {
 

--- a/demo/src/main/java/com/gxj/cropyield/modules/dataset/repository/PriceRecordRepository.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/dataset/repository/PriceRecordRepository.java
@@ -7,6 +7,9 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
+/**
+ * 数据集管理模块的数据访问接口（接口），封装了对数据集管理相关数据表的持久化操作。
+ */
 
 public interface PriceRecordRepository extends JpaRepository<PriceRecord, Long> {
 

--- a/demo/src/main/java/com/gxj/cropyield/modules/dataset/repository/YieldRecordRepository.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/dataset/repository/YieldRecordRepository.java
@@ -8,6 +8,9 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
+/**
+ * 数据集管理模块的数据访问接口（接口），封装了对数据集管理相关数据表的持久化操作。
+ */
 
 @Repository("cropyieldYieldRecordRepository")
 public interface YieldRecordRepository extends JpaRepository<YieldRecord, Long> {

--- a/demo/src/main/java/com/gxj/cropyield/modules/dataset/service/DatasetFileService.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/dataset/service/DatasetFileService.java
@@ -4,6 +4,10 @@ import com.gxj.cropyield.modules.dataset.dto.DatasetFileRequest;
 import com.gxj.cropyield.modules.dataset.entity.DatasetFile;
 
 import java.util.List;
+/**
+ * 数据集管理模块的业务接口（接口），定义数据集管理相关的核心业务操作。
+ * <p>核心方法：listAll、create、deleteByIds。</p>
+ */
 
 public interface DatasetFileService {
 

--- a/demo/src/main/java/com/gxj/cropyield/modules/dataset/service/PriceRecordService.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/dataset/service/PriceRecordService.java
@@ -4,6 +4,10 @@ import com.gxj.cropyield.modules.dataset.dto.PriceRecordRequest;
 import com.gxj.cropyield.modules.dataset.entity.PriceRecord;
 
 import java.util.List;
+/**
+ * 数据集管理模块的业务接口（接口），定义数据集管理相关的核心业务操作。
+ * <p>核心方法：listAll、create。</p>
+ */
 
 public interface PriceRecordService {
 

--- a/demo/src/main/java/com/gxj/cropyield/modules/dataset/service/YieldRecordService.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/dataset/service/YieldRecordService.java
@@ -4,6 +4,10 @@ import com.gxj.cropyield.modules.dataset.dto.YieldRecordRequest;
 import com.gxj.cropyield.modules.dataset.entity.YieldRecord;
 
 import java.util.List;
+/**
+ * 数据集管理模块的业务接口（接口），定义数据集管理相关的核心业务操作。
+ * <p>核心方法：listAll、create。</p>
+ */
 
 public interface YieldRecordService {
 

--- a/demo/src/main/java/com/gxj/cropyield/modules/dataset/service/impl/DatasetFileServiceImpl.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/dataset/service/impl/DatasetFileServiceImpl.java
@@ -24,6 +24,10 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.Objects;
 import java.util.stream.Collectors;
+/**
+ * 数据集管理模块的业务实现类，负责落实数据集管理领域的业务处理逻辑。
+ * <p>核心方法：listAll、create、deleteByIds、archiveImportJobs、cleanupDatasetRecords、recordDeletionJob、collectCleanupImpact、pruneBaseEntities。</p>
+ */
 
 @Service
 public class DatasetFileServiceImpl implements DatasetFileService {

--- a/demo/src/main/java/com/gxj/cropyield/modules/dataset/service/impl/PriceRecordServiceImpl.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/dataset/service/impl/PriceRecordServiceImpl.java
@@ -14,6 +14,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+/**
+ * 数据集管理模块的业务实现类，负责落实数据集管理领域的业务处理逻辑。
+ * <p>核心方法：listAll、create。</p>
+ */
 
 @Service
 public class PriceRecordServiceImpl implements PriceRecordService {

--- a/demo/src/main/java/com/gxj/cropyield/modules/dataset/service/impl/YieldRecordServiceImpl.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/dataset/service/impl/YieldRecordServiceImpl.java
@@ -14,6 +14,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+/**
+ * 数据集管理模块的业务实现类，负责落实数据集管理领域的业务处理逻辑。
+ * <p>核心方法：listAll、create。</p>
+ */
 
 @Service
 public class YieldRecordServiceImpl implements YieldRecordService {

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/config/ForecastEngineConfiguration.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/config/ForecastEngineConfiguration.java
@@ -6,6 +6,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
 
+/**
+ * 预测管理模块的配置类，配置预测管理相关的基础设施与框架行为。
+ * <p>核心方法：forecastRestTemplate。</p>
+ */
 @Configuration
 @EnableConfigurationProperties(ForecastEngineProperties.class)
 public class ForecastEngineConfiguration {

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/config/ForecastEngineProperties.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/config/ForecastEngineProperties.java
@@ -3,6 +3,10 @@ package com.gxj.cropyield.modules.forecast.config;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.time.Duration;
+/**
+ * 预测管理模块的配置类，配置预测管理相关的基础设施与框架行为。
+ * <p>核心方法：getBaseUrl、setBaseUrl、getConnectTimeout、setConnectTimeout、getReadTimeout、setReadTimeout。</p>
+ */
 
 @ConfigurationProperties(prefix = "forecast.engine")
 public class ForecastEngineProperties {

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/config/ForecastModelDataInitializer.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/config/ForecastModelDataInitializer.java
@@ -9,6 +9,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.stereotype.Component;
+/**
+ * 预测管理模块的配置类，配置预测管理相关的基础设施与框架行为。
+ * <p>核心方法：run、ensureDefaultModel。</p>
+ */
 
 @Component
 public class ForecastModelDataInitializer implements ApplicationRunner {

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/controller/ForecastExecutionController.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/controller/ForecastExecutionController.java
@@ -9,6 +9,10 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+/**
+ * 预测管理模块的控制器，用于暴露预测管理相关的 REST 接口。
+ * <p>核心方法：predict。</p>
+ */
 
 @RestController
 @RequestMapping("/api/forecast")

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/controller/ForecastHistoryController.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/controller/ForecastHistoryController.java
@@ -9,6 +9,10 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+/**
+ * 预测管理模块的控制器，用于暴露预测管理相关的 REST 接口。
+ * <p>核心方法：history、deleteHistory。</p>
+ */
 
 @RestController
 @RequestMapping("/api/forecast")

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/controller/ForecastModelController.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/controller/ForecastModelController.java
@@ -12,6 +12,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+/**
+ * 预测管理模块的控制器，用于暴露预测管理相关的 REST 接口。
+ * <p>核心方法：listModels、createModel。</p>
+ */
 
 @RestController
 @RequestMapping("/api/forecast/models")

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/controller/ForecastTaskController.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/controller/ForecastTaskController.java
@@ -12,6 +12,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+/**
+ * 预测管理模块的控制器，用于暴露预测管理相关的 REST 接口。
+ * <p>核心方法：listTasks、createTask。</p>
+ */
 
 @RestController
 @RequestMapping("/api/forecast/tasks")

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/dto/ForecastExecutionRequest.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/dto/ForecastExecutionRequest.java
@@ -3,6 +3,9 @@ package com.gxj.cropyield.modules.forecast.dto;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+/**
+ * 预测管理模块的数据传输对象（记录类型），在预测管理场景下承载参数与返回值。
+ */
 
 public record ForecastExecutionRequest(
     @NotNull Long regionId,

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/dto/ForecastExecutionResponse.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/dto/ForecastExecutionResponse.java
@@ -2,6 +2,9 @@ package com.gxj.cropyield.modules.forecast.dto;
 
 import java.time.LocalDateTime;
 import java.util.List;
+/**
+ * 预测管理模块的数据传输对象（记录类型），在预测管理场景下承载参数与返回值。
+ */
 
 public record ForecastExecutionResponse(
     Long runId,

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/dto/ForecastHistoryPageResponse.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/dto/ForecastHistoryPageResponse.java
@@ -1,6 +1,9 @@
 package com.gxj.cropyield.modules.forecast.dto;
 
 import java.util.List;
+/**
+ * 预测管理模块的数据传输对象（记录类型），在预测管理场景下承载参数与返回值。
+ */
 
 public record ForecastHistoryPageResponse(
     List<ForecastHistoryResponse> items,

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/dto/ForecastHistoryResponse.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/dto/ForecastHistoryResponse.java
@@ -1,6 +1,9 @@
 package com.gxj.cropyield.modules.forecast.dto;
 
 import java.time.LocalDateTime;
+/**
+ * 预测管理模块的数据传输对象（记录类型），在预测管理场景下承载参数与返回值。
+ */
 
 public record ForecastHistoryResponse(
     Long runId,

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/dto/ForecastModelRequest.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/dto/ForecastModelRequest.java
@@ -4,6 +4,9 @@ import com.gxj.cropyield.modules.forecast.entity.ForecastModel.ModelType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+/**
+ * 预测管理模块的数据传输对象（记录类型），在预测管理场景下承载参数与返回值。
+ */
 
 public record ForecastModelRequest(
     @NotBlank(message = "模型名称不能为空")

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/dto/ForecastTaskRequest.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/dto/ForecastTaskRequest.java
@@ -3,6 +3,9 @@ package com.gxj.cropyield.modules.forecast.dto;
 import com.gxj.cropyield.modules.forecast.entity.ForecastTask.TaskStatus;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+/**
+ * 预测管理模块的数据传输对象（记录类型），在预测管理场景下承载参数与返回值。
+ */
 
 public record ForecastTaskRequest(
     @NotNull(message = "模型ID不能为空")

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/engine/Dl4jLstmForecaster.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/engine/Dl4jLstmForecaster.java
@@ -17,11 +17,10 @@ import org.nd4j.linalg.lossfunctions.LossFunctions;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-
 /**
- * Minimal DL4J based forecaster that trains an in-memory LSTM model on the
- * provided history and produces iterative forecasts.
+ * 预测管理模块的业务组件，封装预测管理的算法或执行流程。
  */
+
 class Dl4jLstmForecaster {
 
     private static final int MIN_WINDOW_SIZE = 2;

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/engine/ForecastEngineClient.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/engine/ForecastEngineClient.java
@@ -8,6 +8,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
+/**
+ * 预测管理模块的业务组件，封装预测管理的算法或执行流程。
+ */
 
 @Component
 public class ForecastEngineClient {

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/engine/ForecastEngineRequest.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/engine/ForecastEngineRequest.java
@@ -2,6 +2,9 @@ package com.gxj.cropyield.modules.forecast.engine;
 
 import java.util.List;
 import java.util.Map;
+/**
+ * 预测管理模块的数据传输对象（记录类型），在预测管理场景下承载参数与返回值。
+ */
 
 public record ForecastEngineRequest(
     String modelCode,

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/engine/ForecastEngineResponse.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/engine/ForecastEngineResponse.java
@@ -1,6 +1,9 @@
 package com.gxj.cropyield.modules.forecast.engine;
 
 import java.util.List;
+/**
+ * 预测管理模块的数据传输对象（记录类型），在预测管理场景下承载参数与返回值。
+ */
 
 public record ForecastEngineResponse(
     String requestId,

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/engine/LocalForecastEngine.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/engine/LocalForecastEngine.java
@@ -13,6 +13,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+/**
+ * 预测管理模块的业务组件，封装预测管理的算法或执行流程。
+ */
 
 @Component
 public class LocalForecastEngine {

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/engine/SmileHoltWintersForecaster.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/engine/SmileHoltWintersForecaster.java
@@ -4,11 +4,10 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-
 /**
- * Wrapper around Smile's Holt-Winters implementation with an additive fallback
- * in case the runtime dependency is not available.
+ * 预测管理模块的业务组件，封装预测管理的算法或执行流程。
  */
+
 class SmileHoltWintersForecaster {
 
     private static final double DEFAULT_ALPHA = 0.3;

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/entity/ForecastModel.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/entity/ForecastModel.java
@@ -6,6 +6,9 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
+/**
+ * 预测管理模块的实体类，映射预测管理领域对应的数据表结构。
+ */
 
 @Entity
 @Table(name = "forecast_model")

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/entity/ForecastResult.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/entity/ForecastResult.java
@@ -7,6 +7,9 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+/**
+ * 预测管理模块的实体类，映射预测管理领域对应的数据表结构。
+ */
 
 @Entity
 @Table(name = "forecast_result")

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/entity/ForecastRun.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/entity/ForecastRun.java
@@ -11,6 +11,9 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+/**
+ * 预测管理模块的实体类，映射预测管理领域对应的数据表结构。
+ */
 
 @Entity
 @Table(name = "forecast_run")

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/entity/ForecastRunSeries.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/entity/ForecastRunSeries.java
@@ -7,6 +7,9 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+/**
+ * 预测管理模块的实体类，映射预测管理领域对应的数据表结构。
+ */
 
 @Entity
 @Table(name = "forecast_run_series")

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/entity/ForecastSnapshot.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/entity/ForecastSnapshot.java
@@ -7,6 +7,9 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+/**
+ * 预测管理模块的实体类，映射预测管理领域对应的数据表结构。
+ */
 
 @Entity
 @Table(name = "forecast_snapshot")

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/entity/ForecastTask.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/entity/ForecastTask.java
@@ -4,6 +4,9 @@ import com.gxj.cropyield.common.model.BaseEntity;
 import com.gxj.cropyield.modules.base.entity.Crop;
 import com.gxj.cropyield.modules.base.entity.Region;
 import jakarta.persistence.*;
+/**
+ * 预测管理模块的实体类，映射预测管理领域对应的数据表结构。
+ */
 
 @Entity
 @Table(name = "forecast_task")

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/repository/ForecastModelRepository.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/repository/ForecastModelRepository.java
@@ -3,6 +3,9 @@ package com.gxj.cropyield.modules.forecast.repository;
 import com.gxj.cropyield.modules.forecast.entity.ForecastModel;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+/**
+ * 预测管理模块的数据访问接口（接口），封装了对预测管理相关数据表的持久化操作。
+ */
 
 public interface ForecastModelRepository extends JpaRepository<ForecastModel, Long> {
     Optional<ForecastModel> findByName(String name);

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/repository/ForecastResultRepository.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/repository/ForecastResultRepository.java
@@ -4,6 +4,9 @@ import com.gxj.cropyield.modules.forecast.entity.ForecastResult;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+/**
+ * 预测管理模块的数据访问接口（接口），封装了对预测管理相关数据表的持久化操作。
+ */
 
 public interface ForecastResultRepository extends JpaRepository<ForecastResult, Long> {
 

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/repository/ForecastRunRepository.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/repository/ForecastRunRepository.java
@@ -2,6 +2,9 @@ package com.gxj.cropyield.modules.forecast.repository;
 
 import com.gxj.cropyield.modules.forecast.entity.ForecastRun;
 import org.springframework.data.jpa.repository.JpaRepository;
+/**
+ * 预测管理模块的数据访问接口（接口），封装了对预测管理相关数据表的持久化操作。
+ */
 
 public interface ForecastRunRepository extends JpaRepository<ForecastRun, Long> {
 

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/repository/ForecastRunSeriesRepository.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/repository/ForecastRunSeriesRepository.java
@@ -4,6 +4,9 @@ import com.gxj.cropyield.modules.forecast.entity.ForecastRunSeries;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+/**
+ * 预测管理模块的数据访问接口（接口），封装了对预测管理相关数据表的持久化操作。
+ */
 
 public interface ForecastRunSeriesRepository extends JpaRepository<ForecastRunSeries, Long> {
 

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/repository/ForecastSnapshotRepository.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/repository/ForecastSnapshotRepository.java
@@ -7,6 +7,9 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+/**
+ * 预测管理模块的数据访问接口（接口），封装了对预测管理相关数据表的持久化操作。
+ */
 
 public interface ForecastSnapshotRepository extends JpaRepository<ForecastSnapshot, Long> {
 

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/repository/ForecastTaskRepository.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/repository/ForecastTaskRepository.java
@@ -4,6 +4,9 @@ import com.gxj.cropyield.modules.forecast.entity.ForecastTask;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+/**
+ * 预测管理模块的数据访问接口（接口），封装了对预测管理相关数据表的持久化操作。
+ */
 
 public interface ForecastTaskRepository extends JpaRepository<ForecastTask, Long> {
 

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/service/ForecastExecutionService.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/service/ForecastExecutionService.java
@@ -2,6 +2,10 @@ package com.gxj.cropyield.modules.forecast.service;
 
 import com.gxj.cropyield.modules.forecast.dto.ForecastExecutionRequest;
 import com.gxj.cropyield.modules.forecast.dto.ForecastExecutionResponse;
+/**
+ * 预测管理模块的业务接口（接口），定义预测管理相关的核心业务操作。
+ * <p>核心方法：runForecast。</p>
+ */
 
 public interface ForecastExecutionService {
 

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/service/ForecastHistoryService.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/service/ForecastHistoryService.java
@@ -1,6 +1,10 @@
 package com.gxj.cropyield.modules.forecast.service;
 
 import com.gxj.cropyield.modules.forecast.dto.ForecastHistoryPageResponse;
+/**
+ * 预测管理模块的业务接口（接口），定义预测管理相关的核心业务操作。
+ * <p>核心方法：getHistory、deleteHistory。</p>
+ */
 
 public interface ForecastHistoryService {
 

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/service/ForecastModelService.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/service/ForecastModelService.java
@@ -4,6 +4,10 @@ import com.gxj.cropyield.modules.forecast.dto.ForecastModelRequest;
 import com.gxj.cropyield.modules.forecast.entity.ForecastModel;
 
 import java.util.List;
+/**
+ * 预测管理模块的业务接口（接口），定义预测管理相关的核心业务操作。
+ * <p>核心方法：listAll、create。</p>
+ */
 
 public interface ForecastModelService {
 

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/service/ForecastTaskService.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/service/ForecastTaskService.java
@@ -4,6 +4,10 @@ import com.gxj.cropyield.modules.forecast.dto.ForecastTaskRequest;
 import com.gxj.cropyield.modules.forecast.entity.ForecastTask;
 
 import java.util.List;
+/**
+ * 预测管理模块的业务接口（接口），定义预测管理相关的核心业务操作。
+ * <p>核心方法：listAll、create。</p>
+ */
 
 public interface ForecastTaskService {
 

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/service/impl/ForecastExecutionServiceImpl.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/service/impl/ForecastExecutionServiceImpl.java
@@ -40,6 +40,10 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+/**
+ * 预测管理模块的业务实现类，负责落实预测管理领域的业务处理逻辑。
+ * <p>核心方法：runForecast、persistForecastResults、resolveForecastTask、updateTaskFromRun、createTaskFromRun、buildTaskParameters、buildEvaluationSummary、formatMetricValue。</p>
+ */
 
 @Service
 public class ForecastExecutionServiceImpl implements ForecastExecutionService {

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/service/impl/ForecastHistoryServiceImpl.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/service/impl/ForecastHistoryServiceImpl.java
@@ -24,6 +24,10 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
+/**
+ * 预测管理模块的业务实现类，负责落实预测管理领域的业务处理逻辑。
+ * <p>核心方法：getHistory、deleteHistory、mapSnapshot、resolveForecastResultId、removeForecastResults、deleteSnapshots。</p>
+ */
 
 @Service
 public class ForecastHistoryServiceImpl implements ForecastHistoryService {

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/service/impl/ForecastModelServiceImpl.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/service/impl/ForecastModelServiceImpl.java
@@ -7,6 +7,10 @@ import com.gxj.cropyield.modules.forecast.service.ForecastModelService;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+/**
+ * 预测管理模块的业务实现类，负责落实预测管理领域的业务处理逻辑。
+ * <p>核心方法：listAll、create。</p>
+ */
 
 @Service
 public class ForecastModelServiceImpl implements ForecastModelService {

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/service/impl/ForecastTaskServiceImpl.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/service/impl/ForecastTaskServiceImpl.java
@@ -16,6 +16,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+/**
+ * 预测管理模块的业务实现类，负责落实预测管理领域的业务处理逻辑。
+ * <p>核心方法：listAll、create。</p>
+ */
 
 @Service
 public class ForecastTaskServiceImpl implements ForecastTaskService {

--- a/demo/src/main/java/com/gxj/cropyield/modules/report/controller/ReportController.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/report/controller/ReportController.java
@@ -14,6 +14,10 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+/**
+ * 报表分析模块的控制器，用于暴露报表分析相关的 REST 接口。
+ * <p>核心方法：listReports、createReport、generate、detail。</p>
+ */
 
 @RestController
 @RequestMapping("/api/report")

--- a/demo/src/main/java/com/gxj/cropyield/modules/report/dto/ReportDetailResponse.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/report/dto/ReportDetailResponse.java
@@ -1,6 +1,9 @@
 package com.gxj.cropyield.modules.report.dto;
 
 import java.util.List;
+/**
+ * 报表分析模块的数据传输对象（记录类型），在报表分析场景下承载参数与返回值。
+ */
 
 public record ReportDetailResponse(
     ReportSummaryResponse summary,

--- a/demo/src/main/java/com/gxj/cropyield/modules/report/dto/ReportGenerationRequest.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/report/dto/ReportGenerationRequest.java
@@ -4,6 +4,9 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+/**
+ * 报表分析模块的数据传输对象（记录类型），在报表分析场景下承载参数与返回值。
+ */
 
 public record ReportGenerationRequest(
     @NotNull(message = "请选择分析区域")

--- a/demo/src/main/java/com/gxj/cropyield/modules/report/dto/ReportMetrics.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/report/dto/ReportMetrics.java
@@ -1,4 +1,7 @@
 package com.gxj.cropyield.modules.report.dto;
+/**
+ * 报表分析模块的数据传输对象（记录类型），在报表分析场景下承载参数与返回值。
+ */
 
 public record ReportMetrics(
     long totalReports,

--- a/demo/src/main/java/com/gxj/cropyield/modules/report/dto/ReportOverviewResponse.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/report/dto/ReportOverviewResponse.java
@@ -1,6 +1,9 @@
 package com.gxj.cropyield.modules.report.dto;
 
 import java.util.List;
+/**
+ * 报表分析模块的数据传输对象（记录类型），在报表分析场景下承载参数与返回值。
+ */
 
 public record ReportOverviewResponse(
     List<ReportSummaryResponse> reports,

--- a/demo/src/main/java/com/gxj/cropyield/modules/report/dto/ReportRequest.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/report/dto/ReportRequest.java
@@ -5,6 +5,9 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 import java.time.LocalDateTime;
+/**
+ * 报表分析模块的数据传输对象（记录类型），在报表分析场景下承载参数与返回值。
+ */
 
 public record ReportRequest(
     @NotBlank(message = "报告标题不能为空")

--- a/demo/src/main/java/com/gxj/cropyield/modules/report/dto/ReportSectionResponse.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/report/dto/ReportSectionResponse.java
@@ -1,6 +1,9 @@
 package com.gxj.cropyield.modules.report.dto;
 
 import com.fasterxml.jackson.databind.JsonNode;
+/**
+ * 报表分析模块的数据传输对象（记录类型），在报表分析场景下承载参数与返回值。
+ */
 
 public record ReportSectionResponse(
     Long id,

--- a/demo/src/main/java/com/gxj/cropyield/modules/report/dto/ReportSummaryResponse.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/report/dto/ReportSummaryResponse.java
@@ -1,6 +1,9 @@
 package com.gxj.cropyield.modules.report.dto;
 
 import java.time.LocalDateTime;
+/**
+ * 报表分析模块的数据传输对象（记录类型），在报表分析场景下承载参数与返回值。
+ */
 
 public record ReportSummaryResponse(
     Long id,

--- a/demo/src/main/java/com/gxj/cropyield/modules/report/entity/Report.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/report/entity/Report.java
@@ -16,6 +16,9 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+/**
+ * 报表分析模块的实体类，映射报表分析领域对应的数据表结构。
+ */
 
 @Entity
 @Table(name = "report_summary")

--- a/demo/src/main/java/com/gxj/cropyield/modules/report/entity/ReportSection.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/report/entity/ReportSection.java
@@ -8,6 +8,9 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+/**
+ * 报表分析模块的实体类，映射报表分析领域对应的数据表结构。
+ */
 
 @Entity
 @Table(name = "report_section")

--- a/demo/src/main/java/com/gxj/cropyield/modules/report/repository/ReportRepository.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/report/repository/ReportRepository.java
@@ -5,6 +5,9 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+/**
+ * 报表分析模块的数据访问接口（接口），封装了对报表分析相关数据表的持久化操作。
+ */
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
 

--- a/demo/src/main/java/com/gxj/cropyield/modules/report/service/ReportService.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/report/service/ReportService.java
@@ -5,6 +5,10 @@ import com.gxj.cropyield.modules.report.dto.ReportGenerationRequest;
 import com.gxj.cropyield.modules.report.dto.ReportOverviewResponse;
 import com.gxj.cropyield.modules.report.dto.ReportRequest;
 import com.gxj.cropyield.modules.report.entity.Report;
+/**
+ * 报表分析模块的业务接口（接口），定义报表分析相关的核心业务操作。
+ * <p>核心方法：getOverview、create、generate、getDetail。</p>
+ */
 
 public interface ReportService {
 

--- a/demo/src/main/java/com/gxj/cropyield/modules/report/service/impl/ReportServiceImpl.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/report/service/impl/ReportServiceImpl.java
@@ -48,6 +48,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+/**
+ * 报表分析模块的业务实现类，负责落实报表分析领域的业务处理逻辑。
+ * <p>核心方法：getOverview、create、generate、getDetail、toDetail、toSummary、buildSection、toSectionResponse。</p>
+ */
 
 @Service
 public class ReportServiceImpl implements ReportService {

--- a/demo/src/main/java/com/gxj/cropyield/modules/system/config/SystemSettingSchemaMigrator.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/system/config/SystemSettingSchemaMigrator.java
@@ -7,6 +7,10 @@ import org.springframework.boot.ApplicationRunner;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
+/**
+ * 系统设置模块的配置类，配置系统设置相关的基础设施与框架行为。
+ * <p>核心方法：run、tableExists、createTable、ensureColumn、columnExists、ensureForeignKey、foreignKeyExists、executeDdl。</p>
+ */
 
 @Component
 public class SystemSettingSchemaMigrator implements ApplicationRunner {

--- a/demo/src/main/java/com/gxj/cropyield/modules/system/controller/SystemLogController.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/system/controller/SystemLogController.java
@@ -10,6 +10,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+/**
+ * 系统设置模块的控制器，用于暴露系统设置相关的 REST 接口。
+ * <p>核心方法：listLogs。</p>
+ */
 
 @RestController
 @RequestMapping("/api/system/logs")

--- a/demo/src/main/java/com/gxj/cropyield/modules/system/controller/SystemSettingController.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/system/controller/SystemSettingController.java
@@ -10,6 +10,10 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+/**
+ * 系统设置模块的控制器，用于暴露系统设置相关的 REST 接口。
+ * <p>核心方法：getSettings、updateSettings。</p>
+ */
 
 @RestController
 @RequestMapping("/api/system/settings")

--- a/demo/src/main/java/com/gxj/cropyield/modules/system/dto/SystemSettingRequest.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/system/dto/SystemSettingRequest.java
@@ -2,6 +2,9 @@ package com.gxj.cropyield.modules.system.dto;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Size;
+/**
+ * 系统设置模块的数据传输对象（记录类型），在系统设置场景下承载参数与返回值。
+ */
 
 public record SystemSettingRequest(
     Long defaultRegionId,

--- a/demo/src/main/java/com/gxj/cropyield/modules/system/dto/SystemSettingResponse.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/system/dto/SystemSettingResponse.java
@@ -1,6 +1,9 @@
 package com.gxj.cropyield.modules.system.dto;
 
 import java.time.LocalDateTime;
+/**
+ * 系统设置模块的数据传输对象（记录类型），在系统设置场景下承载参数与返回值。
+ */
 
 public record SystemSettingResponse(
     Long id,

--- a/demo/src/main/java/com/gxj/cropyield/modules/system/entity/SystemLog.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/system/entity/SystemLog.java
@@ -4,6 +4,9 @@ import com.gxj.cropyield.common.model.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+/**
+ * 系统设置模块的实体类，映射系统设置领域对应的数据表结构。
+ */
 
 @Entity
 @Table(name = "sys_log")

--- a/demo/src/main/java/com/gxj/cropyield/modules/system/entity/SystemSetting.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/system/entity/SystemSetting.java
@@ -8,6 +8,9 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+/**
+ * 系统设置模块的实体类，映射系统设置领域对应的数据表结构。
+ */
 
 @Entity
 @Table(name = "system_setting")

--- a/demo/src/main/java/com/gxj/cropyield/modules/system/repository/SystemLogRepository.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/system/repository/SystemLogRepository.java
@@ -2,6 +2,9 @@ package com.gxj.cropyield.modules.system.repository;
 
 import com.gxj.cropyield.modules.system.entity.SystemLog;
 import org.springframework.data.jpa.repository.JpaRepository;
+/**
+ * 系统设置模块的数据访问接口（接口），封装了对系统设置相关数据表的持久化操作。
+ */
 
 public interface SystemLogRepository extends JpaRepository<SystemLog, Long> {
 }

--- a/demo/src/main/java/com/gxj/cropyield/modules/system/repository/SystemSettingRepository.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/system/repository/SystemSettingRepository.java
@@ -4,6 +4,9 @@ import com.gxj.cropyield.modules.system.entity.SystemSetting;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+/**
+ * 系统设置模块的数据访问接口（接口），封装了对系统设置相关数据表的持久化操作。
+ */
 
 public interface SystemSettingRepository extends JpaRepository<SystemSetting, Long> {
 

--- a/demo/src/main/java/com/gxj/cropyield/modules/system/service/SystemLogService.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/system/service/SystemLogService.java
@@ -8,6 +8,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
+/**
+ * 系统设置模块的业务接口，定义系统设置相关的核心业务操作。
+ * <p>核心方法：record、list。</p>
+ */
 @Service
 public class SystemLogService {
 

--- a/demo/src/main/java/com/gxj/cropyield/modules/system/service/SystemSettingService.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/system/service/SystemSettingService.java
@@ -2,6 +2,10 @@ package com.gxj.cropyield.modules.system.service;
 
 import com.gxj.cropyield.modules.system.dto.SystemSettingRequest;
 import com.gxj.cropyield.modules.system.dto.SystemSettingResponse;
+/**
+ * 系统设置模块的业务接口（接口），定义系统设置相关的核心业务操作。
+ * <p>核心方法：getCurrentSettings、updateSettings。</p>
+ */
 
 public interface SystemSettingService {
 

--- a/demo/src/main/java/com/gxj/cropyield/modules/system/service/impl/SystemSettingServiceImpl.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/system/service/impl/SystemSettingServiceImpl.java
@@ -12,6 +12,10 @@ import com.gxj.cropyield.modules.system.service.SystemSettingService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
+/**
+ * 系统设置模块的业务实现类，负责落实系统设置领域的业务处理逻辑。
+ * <p>核心方法：getCurrentSettings、toResponse、updateSettings、createDefaultSetting、normalizeNullable。</p>
+ */
 
 @Service
 public class SystemSettingServiceImpl implements SystemSettingService {

--- a/demo/src/main/java/com/gxj/cropyield/yielddata/YieldRecordController.java
+++ b/demo/src/main/java/com/gxj/cropyield/yielddata/YieldRecordController.java
@@ -13,6 +13,10 @@ import org.springframework.web.bind.annotation.RestController;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.util.List;
+/**
+ * 产量数据模块的控制器，用于暴露产量数据相关的 REST 接口。
+ * <p>核心方法：list、exportExcel、buildFileResponse、exportPdf。</p>
+ */
 
 @RestController("yieldDataRecordController")
 @RequestMapping("/api/yields")

--- a/demo/src/main/java/com/gxj/cropyield/yielddata/YieldRecordService.java
+++ b/demo/src/main/java/com/gxj/cropyield/yielddata/YieldRecordService.java
@@ -29,6 +29,10 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Locale;
+/**
+ * 产量数据模块的业务接口，定义产量数据相关的核心业务操作。
+ * <p>核心方法：search、exportAsExcel、exportAsPdf、setNumeric、addHeaderCell、addBodyCell、buildFilterSummary、formatNumber。</p>
+ */
 
 @Service
 public class YieldRecordService {


### PR DESCRIPTION
## Summary
- add Chinese doc comments across backend controllers, services, entities, repositories, and DTOs to explain their responsibilities
- include key method highlights on core classes to make request flows and business logic easier to trace
- document security and forecast configuration beans to clarify how authentication and engine clients are wired

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68f8b48d47d0832c8be1ac469f713a17