### PR TITLE
Fix admin layout main content scrolling

### DIFF
--- a/forecast/src/layouts/AdminLayout.vue
+++ b/forecast/src/layouts/AdminLayout.vue
@@ -180,5 +180,6 @@ watch(
 
 .main {
   background: #f5f7fa;
+  overflow-y: auto;
 }
 </style>


### PR DESCRIPTION
## Summary
- enable scrolling in the admin layout main content area so long pages (like the data upload form) can be scrolled

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68faf0f4d494832c87a7c7f6f890278c