### PR TITLE
Enforce stronger registration password requirements

### DIFF
--- a/demo/src/main/java/com/gxj/cropyield/modules/auth/service/PasswordPolicyValidator.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/auth/service/PasswordPolicyValidator.java
@@ -13,7 +13,8 @@ import java.util.regex.Pattern;
 @Component
 public class PasswordPolicyValidator {
 
-    private static final Pattern LETTER_PATTERN = Pattern.compile("[A-Za-z]");
+    private static final Pattern UPPERCASE_PATTERN = Pattern.compile("[A-Z]");
+    private static final Pattern LOWERCASE_PATTERN = Pattern.compile("[a-z]");
     private static final Pattern DIGIT_PATTERN = Pattern.compile("\\d");
     private static final Pattern DIGIT_ONLY_PATTERN = Pattern.compile("\\d+");
 
@@ -22,8 +23,10 @@ public class PasswordPolicyValidator {
             throw new BusinessException(ResultCode.BAD_REQUEST, "密码不能为空");
         }
         String password = rawPassword.trim();
-        if (!LETTER_PATTERN.matcher(password).find() || !DIGIT_PATTERN.matcher(password).find()) {
-            throw new BusinessException(ResultCode.BAD_REQUEST, "密码需同时包含字母和数字");
+        if (!UPPERCASE_PATTERN.matcher(password).find()
+                || !LOWERCASE_PATTERN.matcher(password).find()
+                || !DIGIT_PATTERN.matcher(password).find()) {
+            throw new BusinessException(ResultCode.BAD_REQUEST, "密码需同时包含大写字母、小写字母和数字");
         }
         if (isSequentialDigits(password)) {
             throw new BusinessException(ResultCode.BAD_REQUEST, "密码不能为连续数字");

--- a/forecast/src/utils/password.js
+++ b/forecast/src/utils/password.js
@@ -1,4 +1,5 @@
-const hasLetter = value => /[A-Za-z]/.test(value)
+const hasUppercase = value => /[A-Z]/.test(value)
+const hasLowercase = value => /[a-z]/.test(value)
 const hasDigit = value => /\d/.test(value)
 const hasSymbol = value => /[^A-Za-z0-9]/.test(value)
 
@@ -35,8 +36,8 @@ export const validatePasswordPolicy = password => {
   if (password.length < 6) {
     return '密码长度至少为6位'
   }
-  if (!hasLetter(password) || !hasDigit(password)) {
-    return '密码需同时包含字母和数字'
+  if (!hasUppercase(password) || !hasLowercase(password) || !hasDigit(password)) {
+    return '密码需同时包含大写字母、小写字母和数字'
   }
   if (isSequentialDigits(password)) {
     return '密码不能为连续数字'
@@ -55,7 +56,7 @@ export const getPasswordStrength = password => {
   if (password.length >= 10) {
     score += 1
   }
-  if (hasLetter(password) && hasDigit(password)) {
+  if (hasUppercase(password) && hasLowercase(password) && hasDigit(password)) {
     score += 1
   }
   if (hasSymbol(password)) {

--- a/forecast/src/views/RegisterView.vue
+++ b/forecast/src/views/RegisterView.vue
@@ -21,6 +21,7 @@
           </el-form-item>
           <el-form-item label="密码" :error="errors.password">
             <el-input
+              ref="passwordInputRef"
               v-model="form.password"
               placeholder="请输入密码"
               type="password"
@@ -58,6 +59,7 @@
         <div class="form-grid">
           <el-form-item label="确认密码" :error="errors.confirmPassword">
             <el-input
+              ref="confirmPasswordInputRef"
               v-model="form.confirmPassword"
               placeholder="请再次输入密码"
               type="password"
@@ -160,7 +162,7 @@
 </template>
 
 <script setup>
-import { computed, onBeforeUnmount, onMounted, reactive, ref } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, reactive, ref } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { ElMessage } from 'element-plus'
 import { User, Lock, UserFilled, Message, Picture } from '@element-plus/icons-vue'
@@ -204,6 +206,37 @@ const sendCountdown = ref(0)
 const captchaId = ref('')
 const captchaImage = ref('')
 let countdownTimer = null
+
+const passwordInputRef = ref(null)
+const confirmPasswordInputRef = ref(null)
+const clipboardTargets = new Set()
+
+const handlePasswordClipboard = event => {
+  if (event && typeof event.preventDefault === 'function') {
+    event.preventDefault()
+  }
+  ElMessage.warning('密码不支持复制或粘贴')
+}
+
+const attachClipboardGuards = inputComponent => {
+  const inputEl = inputComponent?.input
+  if (!inputEl || clipboardTargets.has(inputEl)) {
+    return
+  }
+  inputEl.addEventListener('paste', handlePasswordClipboard)
+  inputEl.addEventListener('copy', handlePasswordClipboard)
+  inputEl.addEventListener('cut', handlePasswordClipboard)
+  clipboardTargets.add(inputEl)
+}
+
+const detachClipboardGuards = () => {
+  clipboardTargets.forEach(target => {
+    target.removeEventListener('paste', handlePasswordClipboard)
+    target.removeEventListener('copy', handlePasswordClipboard)
+    target.removeEventListener('cut', handlePasswordClipboard)
+  })
+  clipboardTargets.clear()
+}
 
 const passwordStrength = computed(() => getPasswordStrength(form.password))
 
@@ -366,10 +399,19 @@ const goToLogin = () => {
 
 onMounted(() => {
   refreshCaptcha()
+  nextTick(() => {
+    if (passwordInputRef.value) {
+      attachClipboardGuards(passwordInputRef.value)
+    }
+    if (confirmPasswordInputRef.value) {
+      attachClipboardGuards(confirmPasswordInputRef.value)
+    }
+  })
 })
 
 onBeforeUnmount(() => {
   clearCountdown()
+  detachClipboardGuards()
 })
 </script>
 


### PR DESCRIPTION
## Summary
- require registration passwords to include uppercase letters, lowercase letters, and digits on the server
- align the web registration form validation and strength meter with the stronger password policy
- block copy, paste, and cut actions on registration password inputs to prevent clipboard use

## Testing
- `./mvnw test` *(fails: unable to download Maven distribution due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_690b08e28c088324a232d4c2b0e84304