### PR TITLE
Add public notice sharing from system settings

### DIFF
--- a/demo/src/main/java/com/gxj/cropyield/config/ApplicationSecurityConfig.java
+++ b/demo/src/main/java/com/gxj/cropyield/config/ApplicationSecurityConfig.java
@@ -81,6 +81,7 @@ public class ApplicationSecurityConfig {
                 .requestMatchers(HttpMethod.GET, "/api/consultations/**").hasAnyRole("ADMIN", "AGRICULTURE_DEPT", "FARMER")
                 .requestMatchers(HttpMethod.POST, "/api/consultations").hasAnyRole("ADMIN", "FARMER")
                 .requestMatchers(HttpMethod.POST, "/api/consultations/*/messages", "/api/consultations/*/read", "/api/consultations/*/close").hasAnyRole("ADMIN", "AGRICULTURE_DEPT", "FARMER")
+                .requestMatchers(HttpMethod.GET, "/api/system/public-settings").hasAnyRole("ADMIN", "AGRICULTURE_DEPT", "FARMER")
                 .requestMatchers(HttpMethod.PATCH, "/api/consultations/**").hasAnyRole("ADMIN", "AGRICULTURE_DEPT", "FARMER")
                 .requestMatchers(HttpMethod.GET, "/api/system/settings").hasRole("ADMIN")
                 .requestMatchers(HttpMethod.POST, "/api/forecast/models/**", "/api/forecast/tasks/**").hasAnyRole("ADMIN", "AGRICULTURE_DEPT")

--- a/demo/src/main/java/com/gxj/cropyield/modules/system/config/SystemSettingSchemaMigrator.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/system/config/SystemSettingSchemaMigrator.java
@@ -34,6 +34,13 @@ public class SystemSettingSchemaMigrator implements ApplicationRunner {
         ensureColumn("cluster_enabled", "TINYINT(1) NOT NULL DEFAULT 1 AFTER notify_email");
         ensureColumn("pending_change_count", "INT NOT NULL DEFAULT 0 AFTER cluster_enabled");
         ensureColumn("security_strategy", "VARCHAR(64) NULL AFTER pending_change_count");
+        ensureColumn("public_visible", "TINYINT(1) NOT NULL DEFAULT 0 AFTER security_strategy");
+        ensureColumn("public_title", "VARCHAR(128) NULL AFTER public_visible");
+        ensureColumn("public_summary", "VARCHAR(512) NULL AFTER public_title");
+        ensureColumn("public_audience", "VARCHAR(64) NULL AFTER public_summary");
+        ensureColumn("public_level", "VARCHAR(32) NULL AFTER public_audience");
+        ensureColumn("public_start_at", "DATETIME NULL AFTER public_level");
+        ensureColumn("public_end_at", "DATETIME NULL AFTER public_start_at");
         ensureForeignKey();
     }
 
@@ -53,6 +60,13 @@ public class SystemSettingSchemaMigrator implements ApplicationRunner {
             + " cluster_enabled TINYINT(1) NOT NULL DEFAULT 1,"
             + " pending_change_count INT NOT NULL DEFAULT 0,"
             + " security_strategy VARCHAR(64),"
+            + " public_visible TINYINT(1) NOT NULL DEFAULT 0,"
+            + " public_title VARCHAR(128),"
+            + " public_summary VARCHAR(512),"
+            + " public_audience VARCHAR(64),"
+            + " public_level VARCHAR(32),"
+            + " public_start_at DATETIME NULL,"
+            + " public_end_at DATETIME NULL,"
             + " created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,"
             + " updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"
             + ") ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COMMENT = '系统配置项'";

--- a/demo/src/main/java/com/gxj/cropyield/modules/system/controller/PublicSystemSettingController.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/system/controller/PublicSystemSettingController.java
@@ -1,0 +1,27 @@
+package com.gxj.cropyield.modules.system.controller;
+
+import com.gxj.cropyield.common.response.ApiResponse;
+import com.gxj.cropyield.modules.system.dto.PublicNoticeResponse;
+import com.gxj.cropyield.modules.system.service.SystemSettingService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 对外公开的系统设置接口，向非管理员用户提供通知信息。
+ */
+@RestController
+@RequestMapping("/api/system/public-settings")
+public class PublicSystemSettingController {
+
+    private final SystemSettingService systemSettingService;
+
+    public PublicSystemSettingController(SystemSettingService systemSettingService) {
+        this.systemSettingService = systemSettingService;
+    }
+
+    @GetMapping
+    public ApiResponse<PublicNoticeResponse> getPublicNotice() {
+        return ApiResponse.success(systemSettingService.getPublicNotice());
+    }
+}

--- a/demo/src/main/java/com/gxj/cropyield/modules/system/dto/PublicNoticeResponse.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/system/dto/PublicNoticeResponse.java
@@ -1,0 +1,18 @@
+package com.gxj.cropyield.modules.system.dto;
+
+import java.time.LocalDateTime;
+
+/**
+ * 对外公共通知的数据传输对象，仅暴露可展示的信息。
+ */
+public record PublicNoticeResponse(
+    boolean visible,
+    String title,
+    String summary,
+    String audience,
+    String level,
+    LocalDateTime startAt,
+    LocalDateTime endAt,
+    LocalDateTime updatedAt
+) {
+}

--- a/demo/src/main/java/com/gxj/cropyield/modules/system/dto/SystemSettingRequest.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/system/dto/SystemSettingRequest.java
@@ -15,6 +15,17 @@ public record SystemSettingRequest(
     @Min(value = 0, message = "待审批变更数量不能小于0")
     Integer pendingChangeCount,
     @Size(max = 64, message = "安全策略描述不能超过64位")
-    String securityStrategy
+    String securityStrategy,
+    Boolean publicVisible,
+    @Size(max = 128, message = "对外标题长度不能超过128位")
+    String publicTitle,
+    @Size(max = 512, message = "公告摘要长度不能超过512位")
+    String publicSummary,
+    @Size(max = 64, message = "受众描述不能超过64位")
+    String publicAudience,
+    @Size(max = 32, message = "公告级别长度不能超过32位")
+    String publicLevel,
+    java.time.LocalDateTime publicStartAt,
+    java.time.LocalDateTime publicEndAt
 ) {
 }

--- a/demo/src/main/java/com/gxj/cropyield/modules/system/dto/SystemSettingResponse.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/system/dto/SystemSettingResponse.java
@@ -13,6 +13,13 @@ public record SystemSettingResponse(
     boolean clusterEnabled,
     int pendingChangeCount,
     String securityStrategy,
+    boolean publicVisible,
+    String publicTitle,
+    String publicSummary,
+    String publicAudience,
+    String publicLevel,
+    java.time.LocalDateTime publicStartAt,
+    java.time.LocalDateTime publicEndAt,
     LocalDateTime updatedAt
 ) {
 }

--- a/demo/src/main/java/com/gxj/cropyield/modules/system/entity/SystemSetting.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/system/entity/SystemSetting.java
@@ -32,6 +32,27 @@ public class SystemSetting extends BaseEntity {
     @Column(name = "security_strategy", length = 64)
     private String securityStrategy;
 
+    @Column(name = "public_visible", nullable = false)
+    private boolean publicVisible = false;
+
+    @Column(name = "public_title", length = 128)
+    private String publicTitle;
+
+    @Column(name = "public_summary", length = 512)
+    private String publicSummary;
+
+    @Column(name = "public_audience", length = 64)
+    private String publicAudience;
+
+    @Column(name = "public_level", length = 32)
+    private String publicLevel;
+
+    @Column(name = "public_start_at")
+    private java.time.LocalDateTime publicStartAt;
+
+    @Column(name = "public_end_at")
+    private java.time.LocalDateTime publicEndAt;
+
     public Region getDefaultRegion() {
         return defaultRegion;
     }
@@ -70,5 +91,61 @@ public class SystemSetting extends BaseEntity {
 
     public void setSecurityStrategy(String securityStrategy) {
         this.securityStrategy = securityStrategy;
+    }
+
+    public boolean isPublicVisible() {
+        return publicVisible;
+    }
+
+    public void setPublicVisible(boolean publicVisible) {
+        this.publicVisible = publicVisible;
+    }
+
+    public String getPublicTitle() {
+        return publicTitle;
+    }
+
+    public void setPublicTitle(String publicTitle) {
+        this.publicTitle = publicTitle;
+    }
+
+    public String getPublicSummary() {
+        return publicSummary;
+    }
+
+    public void setPublicSummary(String publicSummary) {
+        this.publicSummary = publicSummary;
+    }
+
+    public String getPublicAudience() {
+        return publicAudience;
+    }
+
+    public void setPublicAudience(String publicAudience) {
+        this.publicAudience = publicAudience;
+    }
+
+    public String getPublicLevel() {
+        return publicLevel;
+    }
+
+    public void setPublicLevel(String publicLevel) {
+        this.publicLevel = publicLevel;
+    }
+
+    public java.time.LocalDateTime getPublicStartAt() {
+        return publicStartAt;
+    }
+
+    public void setPublicStartAt(java.time.LocalDateTime publicStartAt) {
+        this.publicStartAt = publicStartAt;
+    }
+
+    public java.time.LocalDateTime getPublicEndAt() {
+        return publicEndAt;
+    }
+
+    public void setPublicEndAt(java.time.LocalDateTime publicEndAt) {
+        this.publicEndAt = publicEndAt;
     }
 }

--- a/demo/src/main/java/com/gxj/cropyield/modules/system/service/SystemSettingService.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/system/service/SystemSettingService.java
@@ -2,6 +2,7 @@ package com.gxj.cropyield.modules.system.service;
 
 import com.gxj.cropyield.modules.system.dto.SystemSettingRequest;
 import com.gxj.cropyield.modules.system.dto.SystemSettingResponse;
+import com.gxj.cropyield.modules.system.dto.PublicNoticeResponse;
 /**
  * 系统设置模块的业务接口（接口），定义系统设置相关的核心业务操作。
  * <p>核心方法：getCurrentSettings、updateSettings。</p>
@@ -12,4 +13,6 @@ public interface SystemSettingService {
     SystemSettingResponse getCurrentSettings();
 
     SystemSettingResponse updateSettings(SystemSettingRequest request);
+
+    PublicNoticeResponse getPublicNotice();
 }

--- a/demo/src/main/java/com/gxj/cropyield/modules/system/service/impl/SystemSettingServiceImpl.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/system/service/impl/SystemSettingServiceImpl.java
@@ -9,6 +9,7 @@ import com.gxj.cropyield.modules.system.dto.SystemSettingResponse;
 import com.gxj.cropyield.modules.system.entity.SystemSetting;
 import com.gxj.cropyield.modules.system.repository.SystemSettingRepository;
 import com.gxj.cropyield.modules.system.service.SystemSettingService;
+import com.gxj.cropyield.modules.system.dto.PublicNoticeResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -60,6 +61,16 @@ public class SystemSettingServiceImpl implements SystemSettingService {
         }
         setting.setSecurityStrategy(normalizeNullable(request.securityStrategy()));
 
+        if (request.publicVisible() != null) {
+            setting.setPublicVisible(request.publicVisible());
+        }
+        setting.setPublicTitle(normalizeNullable(request.publicTitle()));
+        setting.setPublicSummary(normalizeNullable(request.publicSummary()));
+        setting.setPublicAudience(normalizeNullable(request.publicAudience()));
+        setting.setPublicLevel(normalizeNullable(request.publicLevel()));
+        setting.setPublicStartAt(request.publicStartAt());
+        setting.setPublicEndAt(request.publicEndAt());
+
         SystemSetting saved = systemSettingRepository.saveAndFlush(setting);
         return toResponse(saved);
     }
@@ -79,6 +90,30 @@ public class SystemSettingServiceImpl implements SystemSettingService {
             setting.isClusterEnabled(),
             setting.getPendingChangeCount(),
             setting.getSecurityStrategy(),
+            setting.isPublicVisible(),
+            setting.getPublicTitle(),
+            setting.getPublicSummary(),
+            setting.getPublicAudience(),
+            setting.getPublicLevel(),
+            setting.getPublicStartAt(),
+            setting.getPublicEndAt(),
+            setting.getUpdatedAt()
+        );
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PublicNoticeResponse getPublicNotice() {
+        SystemSetting setting = systemSettingRepository.findTopByOrderByIdAsc()
+            .orElseGet(this::createDefaultSetting);
+        return new PublicNoticeResponse(
+            setting.isPublicVisible(),
+            setting.getPublicTitle(),
+            setting.getPublicSummary(),
+            setting.getPublicAudience(),
+            setting.getPublicLevel(),
+            setting.getPublicStartAt(),
+            setting.getPublicEndAt(),
             setting.getUpdatedAt()
         );
     }

--- a/forecast/src/components/PublicNoticeCard.vue
+++ b/forecast/src/components/PublicNoticeCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="notice-card" :class="statusClass">
+  <div class="notice-card" :class="[statusClass, { compact }]">
     <div class="notice-header">
       <div class="notice-badge">平台通知</div>
       <div class="notice-status">
@@ -11,7 +11,7 @@
     <div class="notice-body" v-if="!loading && notice && notice.visible">
       <h3 class="notice-title">{{ notice.title || '系统通知' }}</h3>
       <p class="notice-summary">{{ notice.summary || '暂无摘要，管理员可在系统设置中维护公告内容。' }}</p>
-      <div class="notice-meta">
+      <div class="notice-meta" :class="{ compact }">
         <div class="meta-item">
           <span class="meta-label">受众</span>
           <span class="meta-value">{{ notice.audience || '全体用户' }}</span>
@@ -52,6 +52,10 @@ const props = defineProps({
     default: null
   },
   loading: {
+    type: Boolean,
+    default: false
+  },
+  compact: {
     type: Boolean,
     default: false
   }
@@ -123,6 +127,13 @@ const parseDate = value => {
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
+.notice-card.compact {
+  padding: 14px 16px;
+  min-width: 260px;
+  background: linear-gradient(140deg, rgba(246, 249, 255, 0.85) 0%, rgba(255, 255, 255, 0.92) 100%);
+  box-shadow: 0 10px 24px rgba(61, 92, 255, 0.12);
+}
+
 .notice-card:hover {
   transform: translateY(-2px);
   box-shadow: 0 20px 50px rgba(61, 92, 255, 0.18);
@@ -185,10 +196,18 @@ const parseDate = value => {
   gap: 10px;
 }
 
+.notice-card.compact .notice-body {
+  gap: 8px;
+}
+
 .notice-title {
   margin: 0;
   font-size: 18px;
   color: #0f1f3d;
+}
+
+.notice-card.compact .notice-title {
+  font-size: 16px;
 }
 
 .notice-summary {
@@ -198,6 +217,11 @@ const parseDate = value => {
   font-size: 14px;
 }
 
+.notice-card.compact .notice-summary {
+  font-size: 13px;
+  color: #334155;
+}
+
 .notice-meta {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
@@ -205,6 +229,11 @@ const parseDate = value => {
   padding: 10px;
   border-radius: 12px;
   background: rgba(74, 106, 255, 0.06);
+}
+
+.notice-meta.compact {
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  padding: 8px 10px;
 }
 
 .meta-item {

--- a/forecast/src/components/PublicNoticeCard.vue
+++ b/forecast/src/components/PublicNoticeCard.vue
@@ -1,0 +1,257 @@
+<template>
+  <div class="notice-card" :class="statusClass">
+    <div class="notice-header">
+      <div class="notice-badge">平台通知</div>
+      <div class="notice-status">
+        <span class="status-dot" :class="statusClass" />
+        <span class="status-text">{{ statusLabel }}</span>
+      </div>
+    </div>
+
+    <div class="notice-body" v-if="!loading && notice && notice.visible">
+      <h3 class="notice-title">{{ notice.title || '系统通知' }}</h3>
+      <p class="notice-summary">{{ notice.summary || '暂无摘要，管理员可在系统设置中维护公告内容。' }}</p>
+      <div class="notice-meta">
+        <div class="meta-item">
+          <span class="meta-label">受众</span>
+          <span class="meta-value">{{ notice.audience || '全体用户' }}</span>
+        </div>
+        <div class="meta-item">
+          <span class="meta-label">级别</span>
+          <span class="meta-value">{{ notice.level || '普通' }}</span>
+        </div>
+        <div class="meta-item">
+          <span class="meta-label">生效时间</span>
+          <span class="meta-value">{{ formatRange(notice.startAt, notice.endAt) }}</span>
+        </div>
+        <div class="meta-item">
+          <span class="meta-label">同步时间</span>
+          <span class="meta-value">{{ formatDate(notice.updatedAt) }}</span>
+        </div>
+      </div>
+    </div>
+    <div class="notice-body" v-else-if="loading">
+      <div class="skeleton title" />
+      <div class="skeleton line" />
+      <div class="skeleton line" />
+      <div class="skeleton meta" />
+    </div>
+    <div class="notice-body" v-else>
+      <h3 class="notice-title">暂无公告</h3>
+      <p class="notice-summary">管理员可在系统设置中开启并发布对外通知。</p>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  notice: {
+    type: Object,
+    default: null
+  },
+  loading: {
+    type: Boolean,
+    default: false
+  }
+})
+
+const statusClass = computed(() => {
+  const state = resolveStatus()
+  if (state === 'upcoming') return 'status-upcoming'
+  if (state === 'expired') return 'status-expired'
+  if (state === 'hidden') return 'status-hidden'
+  return 'status-active'
+})
+
+const statusLabel = computed(() => {
+  const state = resolveStatus()
+  switch (state) {
+    case 'upcoming':
+      return '即将生效'
+    case 'expired':
+      return '已过期'
+    case 'hidden':
+      return '未开放'
+    default:
+      return '生效中'
+  }
+})
+
+const resolveStatus = () => {
+  if (!props.notice || !props.notice.visible) return 'hidden'
+  const now = new Date().getTime()
+  const start = parseDate(props.notice.startAt)?.getTime()
+  const end = parseDate(props.notice.endAt)?.getTime()
+  if (start && now < start) return 'upcoming'
+  if (end && now > end) return 'expired'
+  return 'active'
+}
+
+const formatDate = value => {
+  if (!value) return '—'
+  const date = parseDate(value)
+  if (!date) return value
+  return date.toLocaleString('zh-CN', { hour12: false })
+}
+
+const formatRange = (start, end) => {
+  const startText = formatDate(start)
+  const endText = formatDate(end)
+  if (!start && !end) return '长期有效'
+  if (start && !end) return `${startText} 起`
+  if (!start && end) return `即日起 - ${endText}`
+  return `${startText} - ${endText}`
+}
+
+const parseDate = value => {
+  if (!value) return null
+  const parsed = value instanceof Date ? value : new Date(value)
+  return Number.isNaN(parsed.getTime()) ? null : parsed
+}
+</script>
+
+<style scoped>
+.notice-card {
+  position: relative;
+  padding: 20px;
+  border-radius: 18px;
+  background: linear-gradient(140deg, #f6f9ff 0%, #eef3ff 50%, #ffffff 100%);
+  box-shadow: 0 16px 40px rgba(61, 92, 255, 0.12);
+  border: 1px solid rgba(74, 106, 255, 0.1);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.notice-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 50px rgba(61, 92, 255, 0.18);
+}
+
+.notice-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.notice-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(74, 106, 255, 0.12);
+  color: #3a57f7;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+}
+
+.notice-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: #4f5b76;
+}
+
+.status-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  display: inline-block;
+  background: #00c853;
+  box-shadow: 0 0 0 6px rgba(0, 200, 83, 0.12);
+}
+
+.status-active .status-dot {
+  background: #00c853;
+  box-shadow: 0 0 0 6px rgba(0, 200, 83, 0.12);
+}
+
+.status-upcoming .status-dot {
+  background: #ffb300;
+  box-shadow: 0 0 0 6px rgba(255, 179, 0, 0.12);
+}
+
+.status-expired .status-dot,
+.status-hidden .status-dot {
+  background: #c5c9d6;
+  box-shadow: 0 0 0 6px rgba(197, 201, 214, 0.12);
+}
+
+.notice-body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.notice-title {
+  margin: 0;
+  font-size: 18px;
+  color: #0f1f3d;
+}
+
+.notice-summary {
+  margin: 0;
+  color: #44506a;
+  line-height: 1.6;
+  font-size: 14px;
+}
+
+.notice-meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 10px;
+  padding: 10px;
+  border-radius: 12px;
+  background: rgba(74, 106, 255, 0.06);
+}
+
+.meta-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.meta-label {
+  font-size: 12px;
+  color: #6a7796;
+}
+
+.meta-value {
+  font-size: 14px;
+  color: #1f2b47;
+  font-weight: 600;
+}
+
+.skeleton {
+  border-radius: 8px;
+  background: linear-gradient(90deg, #eef1f7 25%, #f6f8fc 50%, #eef1f7 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.2s ease-in-out infinite;
+}
+
+.skeleton.title {
+  width: 70%;
+  height: 18px;
+}
+
+.skeleton.line {
+  width: 100%;
+  height: 12px;
+}
+
+.skeleton.meta {
+  width: 80%;
+  height: 12px;
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+</style>

--- a/forecast/src/layouts/UserLayout.vue
+++ b/forecast/src/layouts/UserLayout.vue
@@ -31,6 +31,12 @@
             <p v-if="userSubtitle" class="header-subtitle">{{ userSubtitle }}</p>
           </div>
           <div class="header-actions">
+            <PublicNoticeCard
+              class="header-notice"
+              :notice="publicNotice"
+              :loading="noticeLoading"
+              compact
+            />
             <WeatherWidget class="header-weather" />
             <div class="user-info">
               <div class="user-name">{{ displayName }}</div>
@@ -63,11 +69,13 @@
 </template>
 
 <script setup>
-import { computed, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useAuthStore } from '../stores/auth'
 import { useAuthorization } from '../composables/useAuthorization'
 import WeatherWidget from '../components/weather/WeatherWidget.vue'
+import PublicNoticeCard from '../components/PublicNoticeCard.vue'
+import apiClient from '../services/http'
 
 const route = useRoute()
 const router = useRouter()
@@ -144,6 +152,21 @@ const displayRoles = computed(() => {
   return roles.join(' / ')
 })
 
+const publicNotice = ref(null)
+const noticeLoading = ref(false)
+
+const fetchPublicNotice = async () => {
+  noticeLoading.value = true
+  try {
+    const { data } = await apiClient.get('/api/system/public-settings')
+    publicNotice.value = data?.data ?? data ?? null
+  } catch (error) {
+    publicNotice.value = null
+  } finally {
+    noticeLoading.value = false
+  }
+}
+
 const userSubtitle = computed(() => {
   if (!displayName.value || displayName.value === '未登录') {
     return ''
@@ -194,6 +217,10 @@ const handleLogout = async () => {
     authStore.logout()
   }
 }
+
+onMounted(() => {
+  fetchPublicNotice()
+})
 
 watch(
   () => [route.name, menuItems.value],
@@ -393,12 +420,20 @@ watch(
 .header-actions {
   margin-left: auto;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 16px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .header-weather {
   flex: 0 0 auto;
+}
+
+.header-notice {
+  flex: 1 1 320px;
+  max-width: 440px;
+  min-width: 260px;
 }
 
 .user-info {

--- a/forecast/src/views/DashboardView.vue
+++ b/forecast/src/views/DashboardView.vue
@@ -34,7 +34,6 @@
             <li v-for="notice in reminders" :key="notice">{{ notice }}</li>
           </ul>
         </div>
-        <PublicNoticeCard class="notice-widget" :notice="publicNotice" :loading="noticeLoading" />
       </div>
     </section>
 
@@ -178,7 +177,6 @@ import { ElMessage, ElMessageBox } from 'element-plus'
 import apiClient from '../services/http'
 import { deleteForecastRun } from '@/services/forecast'
 import { useAuthStore } from '@/stores/auth'
-import PublicNoticeCard from '@/components/PublicNoticeCard.vue'
 
 const authStore = useAuthStore()
 const isUserTheme = computed(() => {
@@ -194,9 +192,6 @@ const summary = ref(null)
 const summaryLoading = ref(false)
 const deletingRunId = ref(null)
 const exporting = reactive({ excel: false, pdf: false })
-const publicNotice = ref(null)
-const noticeLoading = ref(false)
-
 const TABLE_PAGE_SIZE = 5
 const tablePagination = reactive({ page: 1, size: TABLE_PAGE_SIZE })
 
@@ -380,18 +375,6 @@ const fetchDashboardSummary = async () => {
     ElMessage.error(error?.response?.data?.message || '加载仪表盘数据失败')
   } finally {
     summaryLoading.value = false
-  }
-}
-
-const fetchPublicNotice = async () => {
-  noticeLoading.value = true
-  try {
-    const { data } = await apiClient.get('/api/system/public-settings')
-    publicNotice.value = data?.data ?? data ?? null
-  } catch (error) {
-    publicNotice.value = null
-  } finally {
-    noticeLoading.value = false
   }
 }
 
@@ -710,7 +693,6 @@ const handleExportPdf = () => {
 
 onMounted(() => {
   fetchDashboardSummary()
-  fetchPublicNotice()
 })
 
 watch(
@@ -936,10 +918,6 @@ const tableCellStyle = () => ({
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: 16px;
-}
-
-.notice-widget {
-  grid-column: 1 / -1;
 }
 
 .extra-card {

--- a/forecast/src/views/DashboardView.vue
+++ b/forecast/src/views/DashboardView.vue
@@ -34,6 +34,7 @@
             <li v-for="notice in reminders" :key="notice">{{ notice }}</li>
           </ul>
         </div>
+        <PublicNoticeCard class="notice-widget" :notice="publicNotice" :loading="noticeLoading" />
       </div>
     </section>
 
@@ -177,6 +178,7 @@ import { ElMessage, ElMessageBox } from 'element-plus'
 import apiClient from '../services/http'
 import { deleteForecastRun } from '@/services/forecast'
 import { useAuthStore } from '@/stores/auth'
+import PublicNoticeCard from '@/components/PublicNoticeCard.vue'
 
 const authStore = useAuthStore()
 const isUserTheme = computed(() => {
@@ -192,6 +194,8 @@ const summary = ref(null)
 const summaryLoading = ref(false)
 const deletingRunId = ref(null)
 const exporting = reactive({ excel: false, pdf: false })
+const publicNotice = ref(null)
+const noticeLoading = ref(false)
 
 const TABLE_PAGE_SIZE = 5
 const tablePagination = reactive({ page: 1, size: TABLE_PAGE_SIZE })
@@ -376,6 +380,18 @@ const fetchDashboardSummary = async () => {
     ElMessage.error(error?.response?.data?.message || '加载仪表盘数据失败')
   } finally {
     summaryLoading.value = false
+  }
+}
+
+const fetchPublicNotice = async () => {
+  noticeLoading.value = true
+  try {
+    const { data } = await apiClient.get('/api/system/public-settings')
+    publicNotice.value = data?.data ?? data ?? null
+  } catch (error) {
+    publicNotice.value = null
+  } finally {
+    noticeLoading.value = false
   }
 }
 
@@ -694,6 +710,7 @@ const handleExportPdf = () => {
 
 onMounted(() => {
   fetchDashboardSummary()
+  fetchPublicNotice()
 })
 
 watch(
@@ -919,6 +936,10 @@ const tableCellStyle = () => ({
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: 16px;
+}
+
+.notice-widget {
+  grid-column: 1 / -1;
 }
 
 .extra-card {

--- a/forecast/src/views/SystemSettingView.vue
+++ b/forecast/src/views/SystemSettingView.vue
@@ -142,6 +142,59 @@
         <el-form-item label="模型计算集群">
           <el-switch v-model="settings.clusterEnabled" />
         </el-form-item>
+
+        <el-divider content-position="left">对外通知卡片</el-divider>
+        <el-form-item label="开启对外公告">
+          <div class="public-visible">
+            <el-switch v-model="settings.publicVisible" />
+            <div class="hint-text">开启后将在用户/部门端仪表盘以卡片形式展示通知信息。</div>
+          </div>
+        </el-form-item>
+        <el-form-item label="公告标题">
+          <el-input v-model="settings.publicTitle" placeholder="示例：系统维护公告" maxlength="128" show-word-limit />
+        </el-form-item>
+        <el-form-item label="公告摘要">
+          <el-input
+            v-model="settings.publicSummary"
+            type="textarea"
+            :autosize="{ minRows: 2, maxRows: 4 }"
+            placeholder="简要描述公告内容，将在仪表盘卡片中展示"
+            maxlength="512"
+            show-word-limit
+          />
+        </el-form-item>
+        <el-row :gutter="16">
+          <el-col :xs="24" :sm="12">
+            <el-form-item label="受众描述">
+              <el-input v-model="settings.publicAudience" placeholder="例如 全体用户 / 农业部门" maxlength="64" show-word-limit />
+            </el-form-item>
+          </el-col>
+          <el-col :xs="24" :sm="12">
+            <el-form-item label="公告级别">
+              <el-input v-model="settings.publicLevel" placeholder="例如 重要 / 提醒" maxlength="32" show-word-limit />
+            </el-form-item>
+          </el-col>
+        </el-row>
+        <el-form-item label="生效时间">
+          <div class="public-range">
+            <el-date-picker
+              v-model="settings.publicStartAt"
+              type="datetime"
+              value-format="YYYY-MM-DD[T]HH:mm:ss"
+              placeholder="开始时间（可选）"
+              style="width: 100%"
+            />
+            <span class="range-split">至</span>
+            <el-date-picker
+              v-model="settings.publicEndAt"
+              type="datetime"
+              value-format="YYYY-MM-DD[T]HH:mm:ss"
+              placeholder="结束时间（可选）"
+              style="width: 100%"
+            />
+          </div>
+          <div class="hint-text">未填写开始或结束时间时视为长期有效，前端会自动标记状态。</div>
+        </el-form-item>
       </el-form>
     </el-card>
   </div>
@@ -164,6 +217,13 @@ const settings = reactive({
   clusterEnabled: true,
   pendingChangeCount: 0,
   securityStrategy: '',
+  publicVisible: false,
+  publicTitle: '',
+  publicSummary: '',
+  publicAudience: '',
+  publicLevel: '',
+  publicStartAt: null,
+  publicEndAt: null,
   updatedAt: null
 })
 
@@ -237,6 +297,12 @@ const reminders = computed(() => {
     notices.push('当前集群关闭，建议在高峰任务前开启以保障性能')
   }
 
+  if (settings.publicVisible) {
+    notices.push(`公告已对外展示：${settings.publicTitle || '系统公告'}`)
+  } else {
+    notices.push('对外公告未开启，用户端不会展示通知卡片')
+  }
+
   notices.push(`默认区域已设置为「${defaultRegionName.value}」，可通过下方区域管理动态调整`)
   return notices
 })
@@ -296,6 +362,13 @@ const applySettings = payload => {
   settings.clusterEnabled = Boolean(payload?.clusterEnabled)
   settings.pendingChangeCount = Number(payload?.pendingChangeCount ?? 0)
   settings.securityStrategy = payload?.securityStrategy ?? ''
+  settings.publicVisible = Boolean(payload?.publicVisible)
+  settings.publicTitle = payload?.publicTitle ?? ''
+  settings.publicSummary = payload?.publicSummary ?? ''
+  settings.publicAudience = payload?.publicAudience ?? ''
+  settings.publicLevel = payload?.publicLevel ?? ''
+  settings.publicStartAt = payload?.publicStartAt ?? payload?.public_start_at ?? null
+  settings.publicEndAt = payload?.publicEndAt ?? payload?.public_end_at ?? null
   const updatedAtValue = payload?.updatedAt ?? payload?.updated_at ?? null
   settings.updatedAt = updatedAtValue ?? settings.updatedAt ?? null
   ensureDefaultRegionValidity()
@@ -467,7 +540,14 @@ const save = async () => {
       notifyEmail: settings.notifyEmail.trim() ? settings.notifyEmail.trim() : null,
       clusterEnabled: settings.clusterEnabled,
       pendingChangeCount: settings.pendingChangeCount,
-      securityStrategy: settings.securityStrategy.trim() ? settings.securityStrategy.trim() : null
+      securityStrategy: settings.securityStrategy.trim() ? settings.securityStrategy.trim() : null,
+      publicVisible: settings.publicVisible,
+      publicTitle: settings.publicTitle.trim() ? settings.publicTitle.trim() : null,
+      publicSummary: settings.publicSummary.trim() ? settings.publicSummary.trim() : null,
+      publicAudience: settings.publicAudience.trim() ? settings.publicAudience.trim() : null,
+      publicLevel: settings.publicLevel.trim() ? settings.publicLevel.trim() : null,
+      publicStartAt: settings.publicStartAt || null,
+      publicEndAt: settings.publicEndAt || null
     }
     const { data } = await apiClient.put('/api/system/settings', payload)
     const applied = data?.data ?? data ?? {}
@@ -760,6 +840,30 @@ const save = async () => {
 
 .setting-form {
   margin-top: 12px;
+}
+
+.public-visible {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.public-range {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 10px;
+  align-items: center;
+}
+
+.range-split {
+  color: #9aa4b5;
+  font-size: 13px;
+}
+
+.hint-text {
+  margin-top: 6px;
+  color: #7b8aa5;
+  font-size: 12px;
 }
 
 @media (max-width: 992px) {


### PR DESCRIPTION
## Summary
- add public notice metadata to system settings and expose a read-only API for non-admin users
- extend the admin settings page with public notice fields and validation for announcements
- surface the published notice on the dashboard via a new card component

## Testing
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692eaae518648324ae3dec51762106dd)