### PR TITLE
Fix system settings read-only transaction error

### DIFF
--- a/demo/src/main/java/com/gxj/cropyield/modules/system/service/impl/SystemSettingServiceImpl.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/system/service/impl/SystemSettingServiceImpl.java
@@ -31,7 +31,7 @@ public class SystemSettingServiceImpl implements SystemSettingService {
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional
     public SystemSettingResponse getCurrentSettings() {
         SystemSetting setting = systemSettingRepository.findTopByOrderByIdAsc()
             .orElseGet(this::createDefaultSetting);
@@ -102,7 +102,7 @@ public class SystemSettingServiceImpl implements SystemSettingService {
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional
     public PublicNoticeResponse getPublicNotice() {
         SystemSetting setting = systemSettingRepository.findTopByOrderByIdAsc()
             .orElseGet(this::createDefaultSetting);


### PR DESCRIPTION
## Summary
- allow system settings retrieval and public notice queries to run in writeable transactions when initializing defaults
- prevent read-only connection errors when the settings record does not yet exist

## Testing
- `sh mvnw -q -DskipTests package` *(fails: Maven binary download blocked)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69311bd51bdc8324a9194ba5eb23585f)