### PR TITLE
Handle default system setting creation in new transaction

### DIFF
--- a/demo/src/main/java/com/gxj/cropyield/modules/system/service/impl/SystemSettingServiceImpl.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/system/service/impl/SystemSettingServiceImpl.java
@@ -12,6 +12,9 @@ import com.gxj.cropyield.modules.system.service.SystemSettingService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.util.StringUtils;
 /**
  * 系统设置模块的业务实现类，负责落实系统设置领域的业务处理逻辑。
@@ -23,11 +26,14 @@ public class SystemSettingServiceImpl implements SystemSettingService {
 
     private final SystemSettingRepository systemSettingRepository;
     private final RegionRepository regionRepository;
+    private final TransactionTemplate transactionTemplate;
 
     public SystemSettingServiceImpl(SystemSettingRepository systemSettingRepository,
-                                    RegionRepository regionRepository) {
+                                    RegionRepository regionRepository,
+                                    PlatformTransactionManager transactionManager) {
         this.systemSettingRepository = systemSettingRepository;
         this.regionRepository = regionRepository;
+        this.transactionTemplate = createRequiresNewTemplate(transactionManager);
     }
 
     @Override
@@ -67,12 +73,23 @@ public class SystemSettingServiceImpl implements SystemSettingService {
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     protected SystemSetting createDefaultSettingInNewTransaction() {
-        return createDefaultSetting();
+        return createDefaultSettingWithTemplate();
     }
 
     private SystemSetting createDefaultSetting() {
         SystemSetting setting = new SystemSetting();
         return systemSettingRepository.save(setting);
+    }
+
+    private SystemSetting createDefaultSettingWithTemplate() {
+        return transactionTemplate.execute(status -> createDefaultSetting());
+    }
+
+    private TransactionTemplate createRequiresNewTemplate(PlatformTransactionManager transactionManager) {
+        TransactionTemplate template = new TransactionTemplate(transactionManager);
+        template.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        template.setReadOnly(false);
+        return template;
     }
 
     private SystemSettingResponse toResponse(SystemSetting setting) {


### PR DESCRIPTION
## Summary
- keep the current settings query read-only while creating defaults in a separate write transaction when none exist
- add a requires-new transaction helper so default settings can be created without read-only violations

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69311efcc5948324aa79397de30b4cb4)