### PR TITLE
Allow non-admins to retrieve system announcements

### DIFF
--- a/demo/forecast/src/components/AnnouncementCard.vue
+++ b/demo/forecast/src/components/AnnouncementCard.vue
@@ -9,7 +9,7 @@
     </div>
     <h4 class="card-title">{{ announcement?.title || '平台通知' }}</h4>
     <p class="card-message">{{ displayMessage }}</p>
-    <div v-if="displayEmail" class="card-email">
+    <div class="card-email">
       <span class="email-label">通知邮箱</span>
       <span class="email-value">{{ displayEmail }}</span>
     </div>
@@ -36,7 +36,11 @@ const props = defineProps({
 
 const statusValue = computed(() => (props.announcement?.status || 'INACTIVE').toUpperCase())
 const displayMessage = computed(() => props.announcement?.message || '暂无通知内容')
-const displayEmail = computed(() => (props.announcement?.notifyEmail || '').trim())
+const displayEmail = computed(() => {
+  const raw = props.announcement?.notifyEmail ?? props.announcement?.notify_email ?? ''
+  const normalized = typeof raw === 'string' ? raw.trim() : ''
+  return normalized || '未配置'
+})
 
 const updatedAtText = computed(() => {
   const raw = props.announcement?.updatedAt

--- a/demo/forecast/src/components/AnnouncementCard.vue
+++ b/demo/forecast/src/components/AnnouncementCard.vue
@@ -9,6 +9,10 @@
     </div>
     <h4 class="card-title">{{ announcement?.title || '平台通知' }}</h4>
     <p class="card-message">{{ displayMessage }}</p>
+    <div v-if="displayEmail" class="card-email">
+      <span class="email-label">通知邮箱</span>
+      <span class="email-value">{{ displayEmail }}</span>
+    </div>
     <div class="card-footer">
       <span class="footer-label">{{ statusValue === 'ACTIVE' ? '正在展示给所有用户' : '未生效' }}</span>
       <el-link v-if="announcement?.link" type="primary" :href="announcement.link" target="_blank">查看详情</el-link>
@@ -32,6 +36,7 @@ const props = defineProps({
 
 const statusValue = computed(() => (props.announcement?.status || 'INACTIVE').toUpperCase())
 const displayMessage = computed(() => props.announcement?.message || '暂无通知内容')
+const displayEmail = computed(() => (props.announcement?.notifyEmail || '').trim())
 
 const updatedAtText = computed(() => {
   const raw = props.announcement?.updatedAt
@@ -117,6 +122,28 @@ const updatedAtText = computed(() => {
   font-size: 13px;
   color: #44566c;
   line-height: 1.5;
+}
+
+.card-email {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  margin: 0 0 10px;
+  border-radius: 10px;
+  background: rgba(33, 150, 243, 0.08);
+  color: #1d4d8b;
+  font-size: 12px;
+  word-break: break-all;
+}
+
+.announcement-card.inactive .card-email {
+  background: #eef1f8;
+  color: #42526e;
+}
+
+.email-label {
+  font-weight: 700;
 }
 
 .card-footer {

--- a/demo/forecast/src/stores/announcement.js
+++ b/demo/forecast/src/stores/announcement.js
@@ -34,7 +34,7 @@ export const useAnnouncementStore = defineStore('announcement', {
         this.announcement = {
           title: payload.announcementTitle || '平台通知',
           message: payload.announcementMessage || '暂无通知内容',
-          notifyEmail: payload.notifyEmail || '',
+          notifyEmail: payload.notifyEmail || payload.notify_email || payload.notificationEmail || '',
           status: (payload.announcementStatus || 'INACTIVE').toUpperCase(),
           updatedAt: payload.updatedAt ?? payload.updated_at ?? null
         }

--- a/demo/forecast/src/stores/announcement.js
+++ b/demo/forecast/src/stores/announcement.js
@@ -34,6 +34,7 @@ export const useAnnouncementStore = defineStore('announcement', {
         this.announcement = {
           title: payload.announcementTitle || '平台通知',
           message: payload.announcementMessage || '暂无通知内容',
+          notifyEmail: payload.notifyEmail || '',
           status: (payload.announcementStatus || 'INACTIVE').toUpperCase(),
           updatedAt: payload.updatedAt ?? payload.updated_at ?? null
         }

--- a/demo/src/main/java/com/gxj/cropyield/config/ApplicationSecurityConfig.java
+++ b/demo/src/main/java/com/gxj/cropyield/config/ApplicationSecurityConfig.java
@@ -82,7 +82,7 @@ public class ApplicationSecurityConfig {
                 .requestMatchers(HttpMethod.POST, "/api/consultations").hasAnyRole("ADMIN", "FARMER")
                 .requestMatchers(HttpMethod.POST, "/api/consultations/*/messages", "/api/consultations/*/read", "/api/consultations/*/close").hasAnyRole("ADMIN", "AGRICULTURE_DEPT", "FARMER")
                 .requestMatchers(HttpMethod.PATCH, "/api/consultations/**").hasAnyRole("ADMIN", "AGRICULTURE_DEPT", "FARMER")
-                .requestMatchers(HttpMethod.GET, "/api/system/settings").hasRole("ADMIN")
+                .requestMatchers(HttpMethod.GET, "/api/system/settings").hasAnyRole("ADMIN", "AGRICULTURE_DEPT", "FARMER")
                 .requestMatchers(HttpMethod.POST, "/api/forecast/models/**", "/api/forecast/tasks/**").hasAnyRole("ADMIN", "AGRICULTURE_DEPT")
                 .requestMatchers(HttpMethod.GET, "/api/report/export/**").hasAnyRole("ADMIN", "AGRICULTURE_DEPT")
                 .requestMatchers(HttpMethod.POST, "/api/report/**", "/api/report/export/**").hasAnyRole("ADMIN", "AGRICULTURE_DEPT")


### PR DESCRIPTION
## Summary
- allow agriculture department and farmer roles to fetch system settings so announcements can display outside admin accounts

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6933d7bc39e0832f95fe3fcf580f69bc)