### PR TITLE
Add report export support for PDF and Excel

### DIFF
--- a/demo/src/main/java/com/gxj/cropyield/modules/report/controller/ReportController.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/report/controller/ReportController.java
@@ -6,12 +6,19 @@ import com.gxj.cropyield.modules.report.dto.ReportGenerationRequest;
 import com.gxj.cropyield.modules.report.dto.ReportOverviewResponse;
 import com.gxj.cropyield.modules.report.dto.ReportRequest;
 import com.gxj.cropyield.modules.report.entity.Report;
+import com.gxj.cropyield.modules.report.service.ReportExportResult;
 import com.gxj.cropyield.modules.report.service.ReportService;
 import jakarta.validation.Valid;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 /**
@@ -47,5 +54,18 @@ public class ReportController {
     @GetMapping("/{id}")
     public ApiResponse<ReportDetailResponse> detail(@PathVariable Long id) {
         return ApiResponse.success(reportService.getDetail(id));
+    }
+
+    @GetMapping("/export/{id}")
+    public ResponseEntity<ByteArrayResource> export(@PathVariable Long id,
+                                                    @RequestParam(defaultValue = "pdf") String format) {
+        ReportExportResult result = reportService.export(id, format);
+        ContentDisposition disposition = ContentDisposition.attachment()
+            .filename(result.filename(), java.nio.charset.StandardCharsets.UTF_8)
+            .build();
+        return ResponseEntity.ok()
+            .contentType(result.mediaType())
+            .header(HttpHeaders.CONTENT_DISPOSITION, disposition.toString())
+            .body(new ByteArrayResource(result.data()));
     }
 }

--- a/demo/src/main/java/com/gxj/cropyield/modules/report/service/ReportExportResult.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/report/service/ReportExportResult.java
@@ -1,0 +1,9 @@
+package com.gxj.cropyield.modules.report.service;
+
+import org.springframework.http.MediaType;
+
+/**
+ * 报表导出结果，包含导出字节、文件名与媒体类型信息。
+ */
+public record ReportExportResult(byte[] data, String filename, MediaType mediaType) {
+}

--- a/demo/src/main/java/com/gxj/cropyield/modules/report/service/ReportService.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/report/service/ReportService.java
@@ -19,4 +19,6 @@ public interface ReportService {
     ReportDetailResponse generate(ReportGenerationRequest request);
 
     ReportDetailResponse getDetail(Long id);
+
+    ReportExportResult export(Long id, String format);
 }

--- a/demo/src/main/java/com/gxj/cropyield/modules/report/service/impl/ReportServiceImpl.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/report/service/impl/ReportServiceImpl.java
@@ -356,7 +356,9 @@ public class ReportServiceImpl implements ReportService {
                     JsonNode highlights = section.data() != null ? section.data().get("highlights") : null;
                     if (highlights != null && highlights.isArray() && highlights.size() > 0) {
                         document.add(new Paragraph("重点洞察：", bodyFont));
-                        highlights.forEach(node -> document.add(new Paragraph("• " + node.asText(), bodyFont)));
+                        highlights.forEach(node -> {
+                            document.add(new Paragraph("• " + node.asText(), bodyFont));
+                        });
                     }
                 } else if ("YIELD_TREND".equalsIgnoreCase(section.type())) {
                     PdfPTable table = new PdfPTable(4);
@@ -426,7 +428,11 @@ public class ReportServiceImpl implements ReportService {
                     if (highlights != null && highlights.isArray() && highlights.size() > 0) {
                         Row highlightHeader = sheet.createRow(rowIndex++);
                         highlightHeader.createCell(0).setCellValue("重点洞察");
-                        highlights.forEach(node -> sheet.createRow(rowIndex++).createCell(0).setCellValue(node.asText()));
+                        highlights.forEach(node -> {
+                            sheet.createRow(rowIndex++)
+                                .createCell(0)
+                                .setCellValue(node.asText());
+                        });
                     }
                 } else if ("YIELD_TREND".equalsIgnoreCase(section.type())) {
                     Row headerRow = sheet.createRow(rowIndex++);

--- a/demo/src/main/java/com/gxj/cropyield/modules/report/service/impl/ReportServiceImpl.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/report/service/impl/ReportServiceImpl.java
@@ -428,11 +428,11 @@ public class ReportServiceImpl implements ReportService {
                     if (highlights != null && highlights.isArray() && highlights.size() > 0) {
                         Row highlightHeader = sheet.createRow(rowIndex++);
                         highlightHeader.createCell(0).setCellValue("重点洞察");
-                        highlights.forEach(node -> {
+                        for (JsonNode node : highlights) {
                             sheet.createRow(rowIndex++)
                                 .createCell(0)
                                 .setCellValue(node.asText());
-                        });
+                        }
                     }
                 } else if ("YIELD_TREND".equalsIgnoreCase(section.type())) {
                     Row headerRow = sheet.createRow(rowIndex++);

--- a/forecast/src/services/report.js
+++ b/forecast/src/services/report.js
@@ -9,3 +9,9 @@ export const fetchReportDetail = reportId => apiClient.get(`/api/report/${report
 export const fetchCrops = () => apiClient.get('/api/base/crops')
 
 export const fetchRegions = () => apiClient.get('/api/base/regions')
+
+export const exportReport = (reportId, format = 'pdf') =>
+  apiClient.get(`/api/report/export/${reportId}`, {
+    params: { format },
+    responseType: 'blob'
+  })


### PR DESCRIPTION
## Summary
- add report export endpoint for report resources with format selection
- generate PDF/Excel exports from report details using iText and POI and return download responses
- expose frontend export API and UI controls in the report detail drawer for downloading reports

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69588c9b63a0832d88f63d6afbd70b4d)