### PR TITLE
Add scheduled forecast dispatch, model registry, and i18n support

### DIFF
--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/config/ForecastDispatchScheduler.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/config/ForecastDispatchScheduler.java
@@ -1,0 +1,50 @@
+package com.gxj.cropyield.modules.forecast.config;
+
+import com.gxj.cropyield.modules.forecast.dto.ForecastExecutionRequest;
+import com.gxj.cropyield.modules.forecast.entity.ForecastTask;
+import com.gxj.cropyield.modules.forecast.repository.ForecastTaskRepository;
+import com.gxj.cropyield.modules.forecast.service.ForecastTaskQueue;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * 周期性扫描待处理的预测任务，推送到内部消息队列以解耦执行。
+ */
+@Component
+public class ForecastDispatchScheduler {
+
+    private static final Logger log = LoggerFactory.getLogger(ForecastDispatchScheduler.class);
+
+    private final ForecastTaskRepository forecastTaskRepository;
+    private final ForecastTaskQueue forecastTaskQueue;
+
+    public ForecastDispatchScheduler(ForecastTaskRepository forecastTaskRepository,
+                                     ForecastTaskQueue forecastTaskQueue) {
+        this.forecastTaskRepository = forecastTaskRepository;
+        this.forecastTaskQueue = forecastTaskQueue;
+    }
+
+    @Scheduled(cron = "0 0/30 * * * ?")
+    public void dispatchPendingTasks() {
+        List<ForecastTask> pendingTasks = forecastTaskRepository.findByStatus(ForecastTask.TaskStatus.PENDING);
+        if (pendingTasks.isEmpty()) {
+            return;
+        }
+        log.info("Dispatching {} pending forecast tasks", pendingTasks.size());
+        pendingTasks.forEach(task -> {
+            forecastTaskQueue.publish(new ForecastExecutionRequest(
+                    task.getRegion().getId(),
+                    task.getCrop().getId(),
+                    task.getModel().getId(),
+                    3,
+                    3,
+                    "YEAR"
+            ));
+            task.setStatus(ForecastTask.TaskStatus.RUNNING);
+        });
+        forecastTaskRepository.saveAll(pendingTasks);
+    }
+}

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/config/ForecastModelDataInitializer.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/config/ForecastModelDataInitializer.java
@@ -38,6 +38,16 @@ public class ForecastModelDataInitializer implements ApplicationRunner {
                 ForecastModel.ModelType.WEATHER_REGRESSION,
                 "结合逐年气象特征与历史产量进行多元线性回归，量化天气变化对产量的影响。"
         );
+        ensureDefaultModel(
+                "ARIMA 季节性时序模型",
+                ForecastModel.ModelType.ARIMA,
+                "利用差分、移动平均与季节性分量捕捉产量序列的周期性与趋势。"
+        );
+        ensureDefaultModel(
+                "Prophet 节假日回归模型",
+                ForecastModel.ModelType.PROPHET,
+                "基于 Facebook Prophet，将节假日与季节项回归到产量预测。"
+        );
     }
 
     private void ensureDefaultModel(String name, ForecastModel.ModelType type, String description) {

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/config/ForecastModelSchemaMigrator.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/config/ForecastModelSchemaMigrator.java
@@ -26,9 +26,11 @@ public class ForecastModelSchemaMigrator implements ApplicationRunner {
     public void run(ApplicationArguments args) {
         try {
             int removed = jdbcTemplate.update(
-                    "DELETE FROM forecast_model WHERE type NOT IN (?, ?)",
+                    "DELETE FROM forecast_model WHERE type NOT IN (?, ?, ?, ?)",
                     "LSTM",
-                    "WEATHER_REGRESSION"
+                    "WEATHER_REGRESSION",
+                    "ARIMA",
+                    "PROPHET"
             );
             if (removed > 0) {
                 log.info("Removed {} forecast models with deprecated types", removed);

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/entity/ForecastModel.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/entity/ForecastModel.java
@@ -16,7 +16,9 @@ public class ForecastModel extends BaseEntity {
 
     public enum ModelType {
         LSTM,
-        WEATHER_REGRESSION
+        WEATHER_REGRESSION,
+        ARIMA,
+        PROPHET
     }
 
     @Column(nullable = false, length = 128)

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/entity/ModelRegistry.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/entity/ModelRegistry.java
@@ -1,0 +1,61 @@
+package com.gxj.cropyield.modules.forecast.entity;
+
+import com.gxj.cropyield.common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+
+/**
+ * 记录模型产出的元数据与模型文件落盘位置，便于复现与版本管理。
+ */
+@Entity
+@Table(name = "model_registry")
+public class ModelRegistry extends BaseEntity {
+
+    @Column(nullable = false, length = 128)
+    private String modelName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 32)
+    private ForecastModel.ModelType modelType;
+
+    @Column(nullable = false, length = 255)
+    private String storageUri;
+
+    @Column(length = 1024)
+    private String metricsJson;
+
+    public String getModelName() {
+        return modelName;
+    }
+
+    public void setModelName(String modelName) {
+        this.modelName = modelName;
+    }
+
+    public ForecastModel.ModelType getModelType() {
+        return modelType;
+    }
+
+    public void setModelType(ForecastModel.ModelType modelType) {
+        this.modelType = modelType;
+    }
+
+    public String getStorageUri() {
+        return storageUri;
+    }
+
+    public void setStorageUri(String storageUri) {
+        this.storageUri = storageUri;
+    }
+
+    public String getMetricsJson() {
+        return metricsJson;
+    }
+
+    public void setMetricsJson(String metricsJson) {
+        this.metricsJson = metricsJson;
+    }
+}

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/repository/ForecastTaskRepository.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/repository/ForecastTaskRepository.java
@@ -4,6 +4,7 @@ import com.gxj.cropyield.modules.forecast.entity.ForecastTask;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+import java.util.List;
 /**
  * 预测管理模块的数据访问接口（接口），封装了对预测管理相关数据表的持久化操作。
  */
@@ -15,4 +16,6 @@ public interface ForecastTaskRepository extends JpaRepository<ForecastTask, Long
     boolean existsByRegionId(Long regionId);
 
     Optional<ForecastTask> findByModelIdAndCropIdAndRegionId(Long modelId, Long cropId, Long regionId);
+
+    List<ForecastTask> findByStatus(ForecastTask.TaskStatus status);
 }

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/repository/ModelRegistryRepository.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/repository/ModelRegistryRepository.java
@@ -1,0 +1,10 @@
+package com.gxj.cropyield.modules.forecast.repository;
+
+import com.gxj.cropyield.modules.forecast.entity.ModelRegistry;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * 模型仓库表的持久层接口。
+ */
+public interface ModelRegistryRepository extends JpaRepository<ModelRegistry, Long> {
+}

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/service/ForecastTaskQueue.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/service/ForecastTaskQueue.java
@@ -1,0 +1,10 @@
+package com.gxj.cropyield.modules.forecast.service;
+
+import com.gxj.cropyield.modules.forecast.dto.ForecastExecutionRequest;
+
+public interface ForecastTaskQueue {
+
+    void publish(ForecastExecutionRequest request);
+
+    ForecastExecutionRequest poll();
+}

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/service/ModelRegistryService.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/service/ModelRegistryService.java
@@ -1,0 +1,9 @@
+package com.gxj.cropyield.modules.forecast.service;
+
+import com.gxj.cropyield.modules.forecast.entity.ForecastModel;
+import com.gxj.cropyield.modules.forecast.entity.ModelRegistry;
+
+public interface ModelRegistryService {
+
+    ModelRegistry registerSnapshot(ForecastModel model, String storageUri, String metricsJson);
+}

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/service/impl/ForecastTaskWorker.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/service/impl/ForecastTaskWorker.java
@@ -1,0 +1,39 @@
+package com.gxj.cropyield.modules.forecast.service.impl;
+
+import com.gxj.cropyield.modules.forecast.dto.ForecastExecutionRequest;
+import com.gxj.cropyield.modules.forecast.service.ForecastExecutionService;
+import com.gxj.cropyield.modules.forecast.service.ForecastTaskQueue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * 消费内部消息队列的任务并触发预测执行。
+ */
+@Component
+public class ForecastTaskWorker {
+
+    private static final Logger log = LoggerFactory.getLogger(ForecastTaskWorker.class);
+
+    private final ForecastTaskQueue forecastTaskQueue;
+    private final ForecastExecutionService forecastExecutionService;
+
+    public ForecastTaskWorker(ForecastTaskQueue forecastTaskQueue,
+                              ForecastExecutionService forecastExecutionService) {
+        this.forecastTaskQueue = forecastTaskQueue;
+        this.forecastExecutionService = forecastExecutionService;
+    }
+
+    @Scheduled(fixedDelay = 10000)
+    public void consume() {
+        ForecastExecutionRequest request;
+        while ((request = forecastTaskQueue.poll()) != null) {
+            try {
+                forecastExecutionService.runForecast(request);
+            } catch (Exception ex) {
+                log.error("Failed to execute scheduled forecast task", ex);
+            }
+        }
+    }
+}

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/service/impl/InMemoryForecastTaskQueue.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/service/impl/InMemoryForecastTaskQueue.java
@@ -1,0 +1,25 @@
+package com.gxj.cropyield.modules.forecast.service.impl;
+
+import com.gxj.cropyield.modules.forecast.dto.ForecastExecutionRequest;
+import com.gxj.cropyield.modules.forecast.service.ForecastTaskQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import org.springframework.stereotype.Component;
+
+@Component
+public class InMemoryForecastTaskQueue implements ForecastTaskQueue {
+
+    private final BlockingQueue<ForecastExecutionRequest> queue = new LinkedBlockingQueue<>();
+
+    @Override
+    public void publish(ForecastExecutionRequest request) {
+        if (request != null) {
+            queue.offer(request);
+        }
+    }
+
+    @Override
+    public ForecastExecutionRequest poll() {
+        return queue.poll();
+    }
+}

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/service/impl/ModelRegistryServiceImpl.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/service/impl/ModelRegistryServiceImpl.java
@@ -1,0 +1,37 @@
+package com.gxj.cropyield.modules.forecast.service.impl;
+
+import com.gxj.cropyield.modules.forecast.entity.ForecastModel;
+import com.gxj.cropyield.modules.forecast.entity.ModelRegistry;
+import com.gxj.cropyield.modules.forecast.repository.ModelRegistryRepository;
+import com.gxj.cropyield.modules.forecast.service.ModelRegistryService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ModelRegistryServiceImpl implements ModelRegistryService {
+
+    private static final Logger log = LoggerFactory.getLogger(ModelRegistryServiceImpl.class);
+
+    private final ModelRegistryRepository modelRegistryRepository;
+
+    public ModelRegistryServiceImpl(ModelRegistryRepository modelRegistryRepository) {
+        this.modelRegistryRepository = modelRegistryRepository;
+    }
+
+    @Override
+    @Transactional
+    public ModelRegistry registerSnapshot(ForecastModel model, String storageUri, String metricsJson) {
+        if (model == null || storageUri == null) {
+            log.warn("Skip registering model snapshot due to missing model or storage uri");
+            return null;
+        }
+        ModelRegistry registry = new ModelRegistry();
+        registry.setModelName(model.getName());
+        registry.setModelType(model.getType());
+        registry.setStorageUri(storageUri);
+        registry.setMetricsJson(metricsJson);
+        return modelRegistryRepository.save(registry);
+    }
+}

--- a/demo/src/main/java/com/gxj/cropyield/modules/storage/ObjectStorageService.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/storage/ObjectStorageService.java
@@ -1,0 +1,46 @@
+package com.gxj.cropyield.modules.storage;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/**
+ * 简化版对象存储服务，默认写入本地磁盘，便于后续对接 MinIO/S3。
+ */
+@Service
+public class ObjectStorageService {
+
+    private static final Logger log = LoggerFactory.getLogger(ObjectStorageService.class);
+
+    private final Path basePath;
+
+    public ObjectStorageService(@Value("${object-store.base-path:./object-store}") String basePath) {
+        this.basePath = Path.of(basePath);
+        try {
+            Files.createDirectories(this.basePath);
+        } catch (IOException ex) {
+            log.warn("Unable to create object storage base directory {}", this.basePath, ex);
+        }
+    }
+
+    public String saveText(String folder, String filenamePrefix, String content) {
+        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
+        Path targetFolder = basePath.resolve(folder);
+        try {
+            Files.createDirectories(targetFolder);
+            Path targetFile = targetFolder.resolve(filenamePrefix + "-" + timestamp + ".json");
+            Files.writeString(targetFile, content == null ? "" : content, StandardCharsets.UTF_8);
+            return targetFile.toAbsolutePath().toString();
+        } catch (IOException ex) {
+            log.error("Failed to persist object to {}", targetFolder, ex);
+            return null;
+        }
+    }
+}

--- a/demo/src/main/resources/schema.sql
+++ b/demo/src/main/resources/schema.sql
@@ -150,6 +150,17 @@ CREATE TABLE IF NOT EXISTS forecast_model (
     UNIQUE KEY uq_forecast_model_name (name)
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COMMENT = '预测模型定义';
 
+CREATE TABLE IF NOT EXISTS model_registry (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    model_name VARCHAR(128) NOT NULL,
+    model_type VARCHAR(32) NOT NULL,
+    storage_uri VARCHAR(255) NOT NULL,
+    metrics_json VARCHAR(1024),
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    KEY idx_model_registry_type (model_type)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COMMENT = '预测模型产出与元数据登记';
+
 CREATE TABLE IF NOT EXISTS forecast_task (
     id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     model_id BIGINT UNSIGNED NOT NULL,

--- a/forecast/package.json
+++ b/forecast/package.json
@@ -15,6 +15,7 @@
     "pinia": "^2.2.6",
     "vue": "^3.5.22",
     "vue-router": "^4.4.5",
+    "vue-i18n": "^9.14.1",
     "vuedraggable": "^4.1.0"
   },
   "devDependencies": {

--- a/forecast/src/components/LanguageSwitcher.vue
+++ b/forecast/src/components/LanguageSwitcher.vue
@@ -1,0 +1,31 @@
+<template>
+  <el-select v-model="locale" size="small" class="lang-switch" @change="changeLocale">
+    <el-option label="中文" value="zh" />
+    <el-option label="English" value="en" />
+  </el-select>
+</template>
+
+<script setup>
+import { useI18n } from 'vue-i18n'
+import { computed } from 'vue'
+
+const { locale: i18nLocale } = useI18n()
+
+const locale = computed({
+  get: () => i18nLocale.value,
+  set: (val) => {
+    i18nLocale.value = val
+    localStorage.setItem('app-locale', val)
+  }
+})
+
+const changeLocale = (val) => {
+  locale.value = val
+}
+</script>
+
+<style scoped>
+.lang-switch {
+  width: 120px;
+}
+</style>

--- a/forecast/src/i18n/index.js
+++ b/forecast/src/i18n/index.js
@@ -1,0 +1,58 @@
+import { createI18n } from 'vue-i18n'
+
+const messages = {
+  zh: {
+    app: {
+      title: '农作物产量预测平台',
+      subtitle: '请登录以获取最新预测与数据洞察'
+    },
+    auth: {
+      admin: '管理员登录',
+      user: '用户登录',
+      username: '用户名',
+      password: '密码',
+      captcha: '验证码',
+      refresh: '点击刷新',
+      remember: '记住我',
+      login: '登录',
+      register: '立即注册',
+      switchUser: '切换至用户登录',
+      switchAdmin: '切换至管理员登录',
+      forgot: '忘记密码？',
+      noAccount: '还没有账号？',
+      userEntrance: '普通用户入口？'
+    }
+  },
+  en: {
+    app: {
+      title: 'Crop Yield Forecast Platform',
+      subtitle: 'Sign in to access forecasts and insights'
+    },
+    auth: {
+      admin: 'Admin Login',
+      user: 'User Login',
+      username: 'Username',
+      password: 'Password',
+      captcha: 'Captcha',
+      refresh: 'Click to refresh',
+      remember: 'Remember me',
+      login: 'Sign In',
+      register: 'Sign Up',
+      switchUser: 'Switch to user login',
+      switchAdmin: 'Switch to admin login',
+      forgot: 'Forgot password?',
+      noAccount: "Don't have an account?",
+      userEntrance: 'User entrance?'
+    }
+  }
+}
+
+const storedLocale = localStorage.getItem('app-locale')
+const browserLocale = storedLocale || (navigator.language?.toLowerCase().startsWith('en') ? 'en' : 'zh')
+
+export const i18n = createI18n({
+  legacy: false,
+  locale: browserLocale,
+  fallbackLocale: 'zh',
+  messages
+})

--- a/forecast/src/main.js
+++ b/forecast/src/main.js
@@ -7,6 +7,8 @@ import './style.css'
 import App from './App.vue'
 import router from './router'
 import { useAuthStore } from './stores/auth'
+import { i18n } from './i18n'
+import en from 'element-plus/es/locale/lang/en'
 
 const app = createApp(App)
 const pinia = createPinia()
@@ -21,5 +23,6 @@ try {
 }
 
 app.use(router)
-app.use(ElementPlus, { locale: zhCn })
+app.use(ElementPlus, { locale: i18n.global.locale.value === 'en' ? en : zhCn })
+app.use(i18n)
 app.mount('#app')

--- a/forecast/src/views/LoginView.vue
+++ b/forecast/src/views/LoginView.vue
@@ -3,12 +3,13 @@
     <div class="login-card">
       <div class="login-toggle">
         <el-radio-group v-model="loginMode" size="large" class="login-toggle-group">
-          <el-radio-button label="admin">管理员登录</el-radio-button>
-          <el-radio-button label="user">用户登录</el-radio-button>
+          <el-radio-button label="admin">{{ t('auth.admin') }}</el-radio-button>
+          <el-radio-button label="user">{{ t('auth.user') }}</el-radio-button>
         </el-radio-group>
+        <LanguageSwitcher />
       </div>
       <div class="login-header">
-        <h1>农作物产量预测平台</h1>
+        <h1>{{ t('app.title') }}</h1>
         <p>{{ loginSubtitle }}</p>
       </div>
       <el-alert
@@ -23,7 +24,7 @@
       </el-alert>
       <el-form :model="form" class="login-form" @keyup.enter="handleSubmit">
         <el-form-item>
-          <el-input v-model.trim="form.username" placeholder="用户名" autocomplete="username">
+          <el-input v-model.trim="form.username" :placeholder="t('auth.username')" autocomplete="username">
             <template #prefix>
               <el-icon><User /></el-icon>
             </template>
@@ -32,7 +33,7 @@
         <el-form-item>
           <el-input
             v-model="form.password"
-            placeholder="密码"
+            :placeholder="t('auth.password')"
             type="password"
             autocomplete="current-password"
             show-password
@@ -43,34 +44,34 @@
           </el-input>
         </el-form-item>
         <el-form-item class="captcha-item">
-          <el-input v-model.trim="form.captchaCode" placeholder="验证码">
+          <el-input v-model.trim="form.captchaCode" :placeholder="t('auth.captcha')">
             <template #prefix>
               <el-icon><Picture /></el-icon>
             </template>
           </el-input>
           <div class="captcha-image" @click="refreshCaptcha" role="button">
-            <img v-if="captchaImage" :src="captchaImage" alt="验证码" />
-            <span v-else>点击刷新</span>
+            <img v-if="captchaImage" :src="captchaImage" :alt="t('auth.captcha')" />
+            <span v-else>{{ t('auth.refresh') }}</span>
           </div>
         </el-form-item>
         <div class="form-footer">
-          <el-checkbox v-model="form.rememberMe">记住我</el-checkbox>
-          <el-button type="primary" :loading="loading" @click="handleSubmit" class="login-button">登录</el-button>
+          <el-checkbox v-model="form.rememberMe">{{ t('auth.remember') }}</el-checkbox>
+          <el-button type="primary" :loading="loading" @click="handleSubmit" class="login-button">{{ t('auth.login') }}</el-button>
         </div>
       </el-form>
       <p class="login-mode-hint">{{ loginModeHint }}</p>
       <div class="login-actions">
         <div class="switch-auth">
           <template v-if="loginMode === 'admin'">
-            普通用户入口？
-            <el-link type="primary" @click.prevent="switchToMode('user')">切换至用户登录</el-link>
+            {{ t('auth.userEntrance') }}
+            <el-link type="primary" @click.prevent="switchToMode('user')">{{ t('auth.switchUser') }}</el-link>
           </template>
           <template v-else>
-            还没有账号？
-            <el-link type="primary" @click.prevent="goToRegister">立即注册</el-link>
+            {{ t('auth.noAccount') }}
+            <el-link type="primary" @click.prevent="goToRegister">{{ t('auth.register') }}</el-link>
           </template>
         </div>
-        <el-link type="primary" class="forgot-link" @click.prevent="openForgotPassword">忘记密码？</el-link>
+        <el-link type="primary" class="forgot-link" @click.prevent="openForgotPassword">{{ t('auth.forgot') }}</el-link>
       </div>
     </div>
   </div>
@@ -178,10 +179,13 @@ import { User, Lock, Picture, Message } from '@element-plus/icons-vue'
 import apiClient from '../services/http'
 import { useAuthStore } from '../stores/auth'
 import { getPasswordStrength, validatePasswordPolicy } from '../utils/password'
+import LanguageSwitcher from '../components/LanguageSwitcher.vue'
+import { useI18n } from 'vue-i18n'
 
 const router = useRouter()
 const route = useRoute()
 const authStore = useAuthStore()
+const { t } = useI18n()
 
 const loginMode = ref(route.query.mode === 'user' ? 'user' : 'admin')
 


### PR DESCRIPTION
## Summary
- add ARIMA/Prophet model presets plus a registry and local object storage helper for saved metrics
- schedule pending forecast tasks through an internal queue and worker to automate execution
- integrate vue-i18n with a language switcher and translated login strings

## Testing
- `sh ./mvnw -q test` *(fails: Maven wrapper download blocked by network restrictions)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6958926d86ec832dae5d267c2728fb30)