### PR TITLE
Add forecast model parameter configuration support

### DIFF
--- a/demo/src/main/java/com/gxj/cropyield/common/converter/JsonMapConverter.java
+++ b/demo/src/main/java/com/gxj/cropyield/common/converter/JsonMapConverter.java
@@ -1,0 +1,43 @@
+package com.gxj.cropyield.common.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.Map;
+
+/**
+ * 将 Map<String, Object> 与数据库中的 JSON 字符串相互转换，便于持久化模型参数配置。
+ */
+@Converter(autoApply = false)
+public class JsonMapConverter implements AttributeConverter<Map<String, Object>, String> {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(Map<String, Object> attribute) {
+        if (attribute == null || attribute.isEmpty()) {
+            return "{}";
+        }
+        try {
+            return OBJECT_MAPPER.writeValueAsString(attribute);
+        } catch (JsonProcessingException exception) {
+            throw new IllegalArgumentException("无法序列化模型参数", exception);
+        }
+    }
+
+    @Override
+    public Map<String, Object> convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isBlank()) {
+            return Map.of();
+        }
+        try {
+            return OBJECT_MAPPER.readValue(dbData, new TypeReference<>() {
+            });
+        } catch (JsonProcessingException exception) {
+            throw new IllegalArgumentException("无法反序列化模型参数", exception);
+        }
+    }
+}

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/dto/ForecastExecutionRequest.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/dto/ForecastExecutionRequest.java
@@ -3,6 +3,7 @@ package com.gxj.cropyield.modules.forecast.dto;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import java.util.Map;
 /**
  * 预测管理模块的数据传输对象（记录类型），在预测管理场景下承载参数与返回值。
  */
@@ -13,6 +14,7 @@ public record ForecastExecutionRequest(
     @NotNull Long modelId,
     @Min(1) @Max(3) Integer forecastPeriods,
     @Min(1) Integer historyYears,
-    String frequency
+    String frequency,
+    Map<String, Object> parameters
 ) {
 }

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/dto/ForecastModelRequest.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/dto/ForecastModelRequest.java
@@ -4,6 +4,8 @@ import com.gxj.cropyield.modules.forecast.entity.ForecastModel.ModelType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+
+import java.util.Map;
 /**
  * 预测管理模块的数据传输对象（记录类型），在预测管理场景下承载参数与返回值。
  */
@@ -17,6 +19,9 @@ public record ForecastModelRequest(
     ModelType type,
 
     @Size(max = 512, message = "描述长度不能超过512位")
-    String description
+    String description,
+
+    @NotNull(message = "模型参数不能为空")
+    Map<String, Object> parameters
 ) {
 }

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/entity/ForecastModel.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/entity/ForecastModel.java
@@ -1,11 +1,16 @@
 package com.gxj.cropyield.modules.forecast.entity;
 
+import com.gxj.cropyield.common.converter.JsonMapConverter;
 import com.gxj.cropyield.common.model.BaseEntity;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
+
+import java.util.HashMap;
+import java.util.Map;
 /**
  * 预测管理模块的实体类，映射预测管理领域对应的数据表结构。
  */
@@ -31,6 +36,10 @@ public class ForecastModel extends BaseEntity {
     @Column(length = 512)
     private String description;
 
+    @Convert(converter = JsonMapConverter.class)
+    @Column(name = "parameters", columnDefinition = "TEXT")
+    private Map<String, Object> parameters = new HashMap<>();
+
     public String getName() {
         return name;
     }
@@ -53,5 +62,13 @@ public class ForecastModel extends BaseEntity {
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    public Map<String, Object> getParameters() {
+        return parameters;
+    }
+
+    public void setParameters(Map<String, Object> parameters) {
+        this.parameters = parameters == null ? new HashMap<>() : new HashMap<>(parameters);
     }
 }

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/service/impl/ForecastExecutionServiceImpl.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/service/impl/ForecastExecutionServiceImpl.java
@@ -155,7 +155,7 @@ public class ForecastExecutionServiceImpl implements ForecastExecutionService {
         run.setMeasurementUnit(measurementType.valueUnit());
         forecastRunRepository.save(run);
 
-        ForecastEngineResponse response = invokeEngine(limitedHistory, run);
+        ForecastEngineResponse response = invokeEngine(limitedHistory, run, request.parameters());
 
         run.setStatus(ForecastRun.RunStatus.SUCCESS);
         run.setExternalRequestId(response.requestId());
@@ -419,8 +419,12 @@ public class ForecastExecutionServiceImpl implements ForecastExecutionService {
     }
 
     private ForecastEngineResponse invokeEngine(List<HistoryObservation> history,
-                                                ForecastRun run) {
+                                                ForecastRun run,
+                                                Map<String, Object> userParameters) {
         Map<String, Object> parameters = new HashMap<>();
+        if (userParameters != null && !userParameters.isEmpty()) {
+            parameters.putAll(userParameters);
+        }
         parameters.put("historyYears", run.getHistoryYears());
         parameters.put("frequency", run.getFrequency());
 

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/service/impl/ForecastModelServiceImpl.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/service/impl/ForecastModelServiceImpl.java
@@ -32,6 +32,7 @@ public class ForecastModelServiceImpl implements ForecastModelService {
         model.setName(request.name());
         model.setType(request.type());
         model.setDescription(request.description());
+        model.setParameters(request.parameters());
         return forecastModelRepository.save(model);
     }
 }

--- a/demo/src/main/resources/schema.sql
+++ b/demo/src/main/resources/schema.sql
@@ -145,10 +145,26 @@ CREATE TABLE IF NOT EXISTS forecast_model (
     name VARCHAR(128) NOT NULL,
     type VARCHAR(32) NOT NULL,
     description VARCHAR(512),
+    parameters TEXT,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     UNIQUE KEY uq_forecast_model_name (name)
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COMMENT = '预测模型定义';
+
+SET @ddl := (
+    SELECT IF(
+        COUNT(*) = 0,
+        'ALTER TABLE forecast_model ADD COLUMN parameters TEXT NULL AFTER description',
+        'SELECT 1'
+    )
+    FROM information_schema.columns
+    WHERE table_schema = @current_schema
+      AND table_name = 'forecast_model'
+      AND column_name = 'parameters'
+);
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
 
 CREATE TABLE IF NOT EXISTS model_registry (
     id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,

--- a/forecast/src/views/ForecastCenterView.vue
+++ b/forecast/src/views/ForecastCenterView.vue
@@ -126,6 +126,68 @@
             </el-form-item>
           </el-col>
         </el-row>
+        <div class="model-parameter-panel">
+          <div class="parameter-header">
+            <div>
+              <div class="parameter-title">模型参数</div>
+              <div class="parameter-subtitle">
+                支持在提交预测前调整模型超参或天气情景参数，默认读取模型侧配置，可按需增删。
+              </div>
+            </div>
+            <div class="parameter-actions">
+              <el-button
+                size="small"
+                :disabled="!selectors.modelId"
+                @click="resetModelParameters"
+              >
+                恢复默认
+              </el-button>
+              <el-button
+                type="primary"
+                size="small"
+                plain
+                :disabled="!selectors.modelId"
+                @click="addParameterRow"
+              >
+                新增参数
+              </el-button>
+            </div>
+          </div>
+          <el-empty
+            v-if="!selectors.modelId"
+            description="请选择模型后配置参数"
+            :image-size="120"
+            class="parameter-empty"
+          />
+          <div v-else class="parameter-grid">
+            <div
+              v-for="(param, index) in modelParameters"
+              :key="`param-${index}`"
+              class="parameter-row"
+            >
+              <el-input
+                v-model="param.key"
+                placeholder="参数键（如 futureWeatherFeatures 或 learningRate）"
+                clearable
+              />
+              <el-input
+                v-model="param.value"
+                placeholder="参数值"
+                clearable
+              />
+              <el-button
+                v-if="modelParameters.length > 0"
+                type="danger"
+                link
+                :icon="Delete"
+                @click="removeParameterRow(index)"
+              />
+            </div>
+            <div v-if="!modelParameters.length" class="parameter-placeholder">
+              <el-tag effect="plain" type="info">当前模型未提供默认参数，可手动新增</el-tag>
+            </div>
+          </div>
+        </div>
       </el-form>
       <el-alert
         v-if="errorMessage"
@@ -345,6 +407,7 @@
 <script setup>
 import { computed, onMounted, reactive, ref, watch } from 'vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
+import { Delete } from '@element-plus/icons-vue'
 import BaseChart from '@/components/charts/BaseChart.vue'
 import {
   deleteForecastRun,
@@ -371,6 +434,8 @@ const optionLists = reactive({
   models: []
 })
 
+const modelParameters = ref([])
+
 const cropRequestId = ref(0)
 
 const authStore = useAuthStore()
@@ -395,6 +460,9 @@ const selectedRegion = computed(
 const selectedCrop = computed(
   () => optionLists.crops.find(crop => crop.id === selectors.cropId) || null
 )
+const selectedModel = computed(
+  () => optionLists.models.find(model => model.id === selectors.modelId) || null
+)
 
 const historySeries = ref([])
 const forecastSeries = ref([])
@@ -417,6 +485,70 @@ const errorMessage = ref('')
 const disableSubmit = computed(() => !selectors.regionId || !selectors.cropId || !selectors.modelId)
 
 const hasResult = computed(() => historySeries.value.length > 0 || forecastSeries.value.length > 0)
+
+const normalizeParameterValue = value => {
+  if (value === null || value === undefined) return null
+  if (typeof value === 'number' || typeof value === 'boolean') return value
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (!trimmed) return null
+    const lower = trimmed.toLowerCase()
+    if (lower === 'true') return true
+    if (lower === 'false') return false
+    if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+      try {
+        return JSON.parse(trimmed)
+      } catch (error) {
+        // 保留原始字符串
+      }
+    }
+    const numeric = Number(trimmed)
+    if (!Number.isNaN(numeric) && trimmed === `${numeric}`) {
+      return numeric
+    }
+    return trimmed
+  }
+  return value
+}
+
+const parameterPayload = computed(() => {
+  const payload = {}
+  modelParameters.value.forEach(param => {
+    const key = (param.key || '').trim()
+    if (!key) return
+    const normalized = normalizeParameterValue(param.value)
+    if (normalized !== null && normalized !== undefined) {
+      payload[key] = normalized
+    }
+  })
+  return payload
+})
+
+const syncModelParameters = model => {
+  if (!model || !model.parameters || typeof model.parameters !== 'object') {
+    modelParameters.value = []
+    return
+  }
+  modelParameters.value = Object.entries(model.parameters)
+    .filter(([key]) => key)
+    .map(([key, value]) => ({ key, value: value === undefined || value === null ? '' : String(value) }))
+}
+
+const resetModelParameters = () => {
+  if (selectedModel.value) {
+    syncModelParameters(selectedModel.value)
+  } else {
+    modelParameters.value = []
+  }
+}
+
+const addParameterRow = () => {
+  modelParameters.value.push({ key: '', value: '' })
+}
+
+const removeParameterRow = index => {
+  modelParameters.value.splice(index, 1)
+}
 
 const metricLabel = computed(() => metadata.value?.valueLabel || '产量')
 const metricUnit = computed(() => metadata.value?.valueUnit || '吨 / 公顷')
@@ -1019,7 +1151,8 @@ const runForecast = async () => {
       modelId: selectors.modelId,
       historyYears: selectors.historyYears,
       forecastPeriods: selectors.forecastPeriods,
-      frequency: selectors.frequency
+      frequency: selectors.frequency,
+      parameters: parameterPayload.value
     }
     const result = await executeForecast(payload)
     historySeries.value = result.history
@@ -1068,6 +1201,22 @@ watch(
   () => {
     resetResult()
   }
+)
+
+watch(
+  selectedModel,
+  model => {
+    syncModelParameters(model)
+    resetResult()
+  }
+)
+
+watch(
+  modelParameters,
+  () => {
+    resetResult()
+  },
+  { deep: true }
 )
 
 const formatMetric = value => {
@@ -1607,6 +1756,60 @@ function formatScenarioChange(value) {
   color: #2563eb;
 }
 
+.model-parameter-panel {
+  margin-top: 12px;
+  padding: 12px 16px 16px;
+  border: 1px dashed #d0d7ff;
+  border-radius: 12px;
+  background: #f8fafc;
+}
+
+.parameter-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.parameter-title {
+  font-weight: 700;
+  font-size: 15px;
+  color: #0f172a;
+}
+
+.parameter-subtitle {
+  color: #475569;
+  margin-top: 4px;
+  font-size: 13px;
+}
+
+.parameter-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.parameter-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.parameter-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
+  gap: 12px;
+  align-items: center;
+}
+
+.parameter-placeholder {
+  padding: 8px 0 4px;
+}
+
+.parameter-empty {
+  margin-top: 12px;
+}
+
 @media (max-width: 992px) {
   .hero-card {
     padding: 24px;
@@ -1631,6 +1834,15 @@ function formatScenarioChange(value) {
 
   .card-header > :last-child {
     justify-content: flex-start;
+  }
+
+  .parameter-row {
+    grid-template-columns: 1fr;
+  }
+
+  .parameter-actions {
+    flex-wrap: wrap;
+    justify-content: flex-end;
   }
 }
 </style>

--- a/forecast/src/views/ForecastCenterView.vue
+++ b/forecast/src/views/ForecastCenterView.vue
@@ -131,7 +131,8 @@
             <div>
               <div class="parameter-title">模型参数</div>
               <div class="parameter-subtitle">
-                支持在提交预测前调整模型超参或天气情景参数，默认读取模型侧配置，可按需增删。
+                支持在提交预测前调整模型超参或天气情景参数，默认读取模型侧配置，可按需增删。数值、true/false、
+                JSON 对象/数组或普通字符串均可作为参数值。
               </div>
             </div>
             <div class="parameter-actions">
@@ -160,6 +161,20 @@
             class="parameter-empty"
           />
           <div v-else class="parameter-grid">
+            <el-alert
+              v-if="parameterExamples.length"
+              type="info"
+              :closable="false"
+              class="parameter-hint"
+            >
+              <template #title>常用填法示例</template>
+              <div class="parameter-hint-content">
+                <div class="parameter-hint-row" v-for="item in parameterExamples" :key="item.key">
+                  <el-tag size="small" effect="plain">{{ item.key }}</el-tag>
+                  <span class="parameter-hint-text">{{ item.hint }}</span>
+                </div>
+              </div>
+            </el-alert>
             <div
               v-for="(param, index) in modelParameters"
               :key="`param-${index}`"
@@ -463,6 +478,22 @@ const selectedCrop = computed(
 const selectedModel = computed(
   () => optionLists.models.find(model => model.id === selectors.modelId) || null
 )
+
+const parameterExamples = computed(() => {
+  const defaults = selectedModel.value?.parameters
+  if (defaults && typeof defaults === 'object' && Object.keys(defaults).length > 0) {
+    return Object.entries(defaults).map(([key, value]) => ({
+      key,
+      hint: typeof value === 'object' ? JSON.stringify(value) : String(value)
+    }))
+  }
+  return [
+    { key: 'learningRate', hint: '0.01 或 0.05（数字）' },
+    { key: 'futureWeatherFeatures', hint: '["temp", "rainfall"]（数组 JSON）' },
+    { key: 'useNormalization', hint: 'true / false（布尔值）' },
+    { key: 'seed', hint: '42（可复现随机种子）' }
+  ]
+})
 
 const historySeries = ref([])
 const forecastSeries = ref([])
@@ -1793,6 +1824,30 @@ function formatScenarioChange(value) {
   display: flex;
   flex-direction: column;
   gap: 10px;
+}
+
+.parameter-hint {
+  border: 1px dashed #cbd5e1;
+  background: #f8fafc;
+}
+
+.parameter-hint-content {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+.parameter-hint-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: #475569;
+  font-size: 13px;
+}
+
+.parameter-hint-text {
+  word-break: break-all;
 }
 
 .parameter-row {


### PR DESCRIPTION
## Summary
- add JSON map converter to persist model parameter configurations
- extend forecast model DTO and entity with parameter fields for persistence
- store provided parameters when creating forecast models

## Testing
- mvn -pl . -DskipTests package *(fails: cannot resolve parent POM due to 403 from Maven Central in sandbox)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69589aea04f0832d91a7f1640e27c173)