### PR TITLE
Update Prophet model naming to avoid holiday wording

### DIFF
--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/config/ForecastModelDataInitializer.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/config/ForecastModelDataInitializer.java
@@ -44,9 +44,9 @@ public class ForecastModelDataInitializer implements ApplicationRunner {
                 "利用差分、移动平均与季节性分量捕捉产量序列的周期性与趋势。"
         );
         ensureDefaultModel(
-                "Prophet 节假日回归模型",
+                "Prophet 事件影响模型",
                 ForecastModel.ModelType.PROPHET,
-                "基于 Facebook Prophet，将节假日与季节项回归到产量预测。"
+                "基于 Facebook Prophet，将特殊事件影响与季节项回归到产量预测。"
         );
     }
 

--- a/demo/src/main/java/com/gxj/cropyield/modules/forecast/service/impl/ForecastExecutionServiceImpl.java
+++ b/demo/src/main/java/com/gxj/cropyield/modules/forecast/service/impl/ForecastExecutionServiceImpl.java
@@ -430,10 +430,12 @@ public class ForecastExecutionServiceImpl implements ForecastExecutionService {
 
         Map<Integer, Map<String, Double>> weatherFeatures = Collections.emptyMap();
         Map<String, Map<String, Double>> futureWeatherFeatures = Collections.emptyMap();
+        boolean userProvidedFutureFeatures =
+                userParameters != null && userParameters.containsKey("futureWeatherFeatures");
         if (run.getModel() != null && run.getModel().getType() == ForecastModel.ModelType.WEATHER_REGRESSION) {
             WeatherFeatureBundle bundle = buildWeatherFeatureBundle(run.getRegion(), run.getCrop(), history, run.getForecastPeriods());
             weatherFeatures = bundle.historyFeatures();
-            if (!bundle.futureFeatures().isEmpty()) {
+            if (!userProvidedFutureFeatures && !bundle.futureFeatures().isEmpty()) {
                 Map<String, Map<String, Double>> mapped = new LinkedHashMap<>();
                 for (Map.Entry<Integer, Map<String, Double>> entry : bundle.futureFeatures().entrySet()) {
                     mapped.put(String.valueOf(entry.getKey()), entry.getValue());

--- a/docs/presentation_script.md
+++ b/docs/presentation_script.md
@@ -26,7 +26,7 @@
 
 ## 5. 数据与模型设计
 - 数据库：`schema.sql` 预置 20 余张表，覆盖作物、区域、数据集、预测运行、报表及权限体系；`data.sql` 写入基础作物、角色与管理员账号，确保开箱即用。【F:README.md†L56-L63】
-- 预测模型：默认创建包括 Prophet 节假日回归在内的多种模型，支持节假日与季节性因素建模，兼顾趋势和鲁棒性。【F:docs/thesis_excerpt.txt†L32-L49】
+- 预测模型：默认创建包括 Prophet 事件影响在内的多种模型，支持事件影响与季节性因素建模，兼顾趋势和鲁棒性。【F:docs/thesis_excerpt.txt†L32-L49】
 - 评估与可视化：使用 ECharts 展示产量统计与预测结果，可对不同模型效果进行指标评价与对比。【F:docs/thesis_excerpt.txt†L32-L49】【F:README.md†L69-L96】
 
 ## 6. 演示节奏建议

--- a/forecast/src/views/ForecastCenterView.vue
+++ b/forecast/src/views/ForecastCenterView.vue
@@ -171,7 +171,10 @@
               <div class="parameter-hint-content">
                 <div class="parameter-hint-row" v-for="item in parameterExamples" :key="item.key">
                   <el-tag size="small" effect="plain">{{ item.key }}</el-tag>
-                  <span class="parameter-hint-text">{{ item.hint }}</span>
+                  <div class="parameter-hint-text-block">
+                    <span class="parameter-hint-text">{{ item.hint }}</span>
+                    <span v-if="item.reason" class="parameter-hint-reason">原因：{{ item.reason }}</span>
+                  </div>
                 </div>
               </div>
             </el-alert>
@@ -484,14 +487,31 @@ const parameterExamples = computed(() => {
   if (defaults && typeof defaults === 'object' && Object.keys(defaults).length > 0) {
     return Object.entries(defaults).map(([key, value]) => ({
       key,
-      hint: typeof value === 'object' ? JSON.stringify(value) : String(value)
+      hint: typeof value === 'object' ? JSON.stringify(value) : String(value),
+      reason: ''
     }))
   }
   return [
-    { key: 'learningRate', hint: '0.01 或 0.05（数字）' },
-    { key: 'futureWeatherFeatures', hint: '["temp", "rainfall"]（数组 JSON）' },
-    { key: 'useNormalization', hint: 'true / false（布尔值）' },
-    { key: 'seed', hint: '42（可复现随机种子）' }
+    {
+      key: 'learningRate',
+      hint: '0.01 或 0.05（数字）',
+      reason: '控制收敛速度与稳定性，0.01~0.05 兼顾训练速度与不过拟合'
+    },
+    {
+      key: 'futureWeatherFeatures',
+      hint: '{"2025": {"temp": 20, "rainfall": 800}}（JSON，未来年份→特征值）',
+      reason: '已知未来年份的天气特征时显式传入，可避免模型用均值或趋势外推导致偏差'
+    },
+    {
+      key: 'useNormalization',
+      hint: 'true / false（布尔值）',
+      reason: '特征标准化能减轻量纲差异带来的权重偏置，推荐保持 true'
+    },
+    {
+      key: 'seed',
+      hint: '42（可复现随机种子）',
+      reason: '固定随机过程，便于结果复现和对比'
+    }
   ]
 })
 
@@ -1846,7 +1866,19 @@ function formatScenarioChange(value) {
   font-size: 13px;
 }
 
+.parameter-hint-text-block {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
 .parameter-hint-text {
+  word-break: break-all;
+}
+
+.parameter-hint-reason {
+  color: #64748b;
+  font-size: 12px;
   word-break: break-all;
 }
 

--- a/forecast/src/views/ForecastCenterView.vue
+++ b/forecast/src/views/ForecastCenterView.vue
@@ -499,8 +499,8 @@ const parameterExamples = computed(() => {
     },
     {
       key: 'futureWeatherFeatures',
-      hint: '{"2025": {"temp": 20, "rainfall": 800}}（JSON，未来年份→特征值）',
-      reason: '已知未来年份的天气特征时显式传入，可避免模型用均值或趋势外推导致偏差'
+      hint: '{"2025": {"avgTemp": 20, "rainfall": 800}}（JSON，未来年份→【天气特征名: 特征值】）',
+      reason: '“特征值”指该天气特征的具体数值，如平均气温(℃)、降水量(mm)等；用训练时的特征字段填入未来情景，可避免模型用均值或趋势外推导致偏差'
     },
     {
       key: 'useNormalization',


### PR DESCRIPTION
## Summary
- rename the default Prophet model to "Prophet 事件影响模型" and update its description to avoid holiday wording
- adjust the presentation script to reference the new Prophet model name and terminology

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695b0ed18e708331af61894dea1a3ec0)